### PR TITLE
37 - more fixes for: components base modal component 

### DIFF
--- a/src/components/Dialog/Dialog.scss
+++ b/src/components/Dialog/Dialog.scss
@@ -1,6 +1,7 @@
 // override base '@reach/dialog/styles.css'
 [data-reach-dialog-overlay] {
   background-color: hsla(0, 0%, 0%, 33%);
+  z-index: 3;
 }
 [data-reach-dialog-content] {
   background: hsl(220, 13%, 18%);
@@ -17,7 +18,7 @@
   display: flex;
   flex-direction: column;
   border-radius: 20px;
-  z-index: 3;
+
   // dynamic max width based on viewport size
   width: 90vw;
   @media screen and (min-width: 576px) {


### PR DESCRIPTION
the z-index needs to go on the overlay, because behind components can still come through