### PR TITLE
chore: fix CSS rule in base modal component

### DIFF
--- a/src/components/ScrollableArea/ScrollableArea.scss
+++ b/src/components/ScrollableArea/ScrollableArea.scss
@@ -4,5 +4,5 @@
 }
 
 .scrollable-area--scrolled {
-  box-shadow: hsla(0, 0, 0, 0.1) 0 2px inset;
+  box-shadow: hsla(0, 0%, 0%, 0.1) 0 2px inset;
 }


### PR DESCRIPTION
Fix CSS: saturation and lightness should be defined by % units
    - this occasionally causes a Webpack build warning