### PR TITLE
chore: Remove unused reference to Cosmos registry

### DIFF
--- a/src/lib/web3/useWeb3.tsx
+++ b/src/lib/web3/useWeb3.tsx
@@ -1,10 +1,8 @@
 import * as React from 'react';
 import invariant from 'invariant';
 
-import { OfflineSigner, Registry } from '@cosmjs/proto-signing';
-import { defaultRegistryTypes } from '@cosmjs/stargate';
+import { OfflineSigner } from '@cosmjs/proto-signing';
 import { ChainInfo, Keplr, Window as KeplrWindow } from '@keplr-wallet/types';
-import { MsgDepositShares } from './generated/duality/duality.duality/module/types/duality/tx';
 
 export type Provider = Keplr;
 
@@ -53,11 +51,6 @@ const chainInfo: ChainInfo = {
     bech32PrefixConsPub: `${bech32Prefix}valconspub`,
   },
 };
-
-const registry = new Registry(defaultRegistryTypes);
-
-// add additional Msgs here
-registry.register('/duality.duality.MsgDepositShares', MsgDepositShares);
 
 declare global {
   interface Window extends KeplrWindow {


### PR DESCRIPTION
This PR cleans up some code that should have been included in commit: https://github.com/duality-labz/duality-web-app/pull/88/commits/231b6245e61418f089694069610fffa978382afd as a part of the PR 
- #88 

As the last usage of the `registry` variable was on line 141 of `useWeb3` here: https://github.com/duality-labz/duality-web-app/pull/88/commits/231b6245e61418f089694069610fffa978382afd#diff-9b8e74cd58b4622f957e1d5547eda87deb58c55e9024e70148026e192e4cdebaL141 