### PR TITLE
fix: TokenPicker crash on bad characters by whitelisting good chars

### DIFF
--- a/src/components/TokenPicker/TokenPicker.tsx
+++ b/src/components/TokenPicker/TokenPicker.tsx
@@ -188,9 +188,9 @@ export default function TokenPicker({
       const queryRegexText = searchQuery
         .trim()
         .toLowerCase()
-        .replace(/[.*\\{}[\]+$^]/gi, (char) => `\\${char}`)
-        .replace(/\s+/g, '\\s*')
-        .replace(/^["'](.*)["']$/, '$1'); // remove quotes
+        .replace(/\s+/g, ' ') //condense spaces
+        .replace(/^["']*(.*)["']*$/, '$1') // remove enclosing quotes
+        .replace(/[^a-z0-9 ]/gi, (char) => `\\${char}`); // whitelist ok chars
       const regexQuery = new RegExp(`(${queryRegexText})`, 'i');
 
       setFilteredList(


### PR DESCRIPTION
The TokenPicker would crash the application if a bracket character was entered (ie. `(` or `)`)

This should fix the issue by instead of catching known bad cases, to only accept good cases for our needs. 