### PR TITLE
fix: 148 add current token price information

### DIFF
--- a/src/lib/tokenPrices.ts
+++ b/src/lib/tokenPrices.ts
@@ -143,20 +143,19 @@ export function useSimplePrice(
   tokenOrTokens: (Token | undefined) | (Token | undefined)[],
   currencyID = 'usd'
 ) {
-  const tokens = Array.isArray(tokenOrTokens) ? tokenOrTokens : [tokenOrTokens];
+  const tokens = useMemo(() => {
+    return Array.isArray(tokenOrTokens) ? tokenOrTokens : [tokenOrTokens];
+  }, [tokenOrTokens]);
 
   const { data, error, isValidating } = useSimplePrices(tokens, currencyID);
 
   // cache the found result array so it doesn't generate updates if the values are equal
   const cachedResults = useMemo(() => {
-    const tokens = Array.isArray(tokenOrTokens)
-      ? tokenOrTokens
-      : [tokenOrTokens];
     // return found results as numbers
     return tokens.map(
       (token) => data?.[token?.coingecko_id ?? '']?.[currencyID]
     );
-  }, [tokenOrTokens, data, currencyID]);
+  }, [tokens, data, currencyID]);
 
   return {
     // return array of results or singular result depending on how it was asked


### PR DESCRIPTION
This fix removes the incorrect workaround for exhaustive dependencies for React hooks:
```ts
// eslint-disable-next-line react-hooks/exhaustive-deps
```

The hooks have been redone (a little less efficiently as an extra `useMemo` is needed) in a way to keep the logic clear around creation of the vars `tokens` and `cachedResults`. I thought to rename `cachedResults` to just `results` but this will cause a future merge conflict in the work for the My Liquidity page in #156 which is quite large at the moment.