### PR TITLE
fix: ticks should be red if they are beyond their token price range

### DIFF
--- a/src/components/LiquiditySelector/LiquiditySelector.scss
+++ b/src/components/LiquiditySelector/LiquiditySelector.scss
@@ -45,6 +45,12 @@
   .token-b .tip {
     fill: hsl(202, 41%, 36%);
   }
+  .tick--price-warning {
+    .tip,
+    .line {
+      stroke: var(--error);
+    }
+  }
   .tick--hit-area {
     fill: transparent;
     stroke: none;


### PR DESCRIPTION
This fixes the removal of red tick warnings in https://github.com/duality-labs/duality-web-app/commit/27c194bdba72681c5eebdacdc553fba50bfe716b#diff-a0c9f66e11289015a5cee359cb1c3abccc3e15bc06f1d84a3c670f57e77c4170L53-L55

It's not exactly equivalent: I think setting the line as red is a better and more noticeable indication that the tick is in an error state. This leaves the text fill color to represent whether the tick is currently selected (blue) or not (yellow)