### PR TITLE
fix: remove buttons that do not do anything yet (part 2)

### DIFF
--- a/src/pages/Pool/Pool.tsx
+++ b/src/pages/Pool/Pool.tsx
@@ -90,7 +90,7 @@ export default function Pool() {
   }, [tokenA, tokenList]);
   // set token B to be USDC token in list if not already populated
   useEffect(() => {
-    const USDC = tokenList?.find((token) => token.symbol === 'USDC');
+    const USDC = tokenList?.find((token) => token.symbol === 'STK');
     if (USDC && !tokenB) {
       setTokenB(USDC);
     }


### PR DESCRIPTION
Follows fix: remove buttons that do not do anything yet #191

Forgot to default the starting tokens to only available tokens on the current chain.