### PR TITLE
fix: SVG drawing of NaN heights

### DIFF
--- a/src/components/LiquiditySelector/LiquiditySelector.tsx
+++ b/src/components/LiquiditySelector/LiquiditySelector.tsx
@@ -908,7 +908,9 @@ function TicksGroup({
   );
 
   const tickPart = ticks
-    .filter((tick): tick is Tick => !!tick)
+    .filter(
+      (tick): tick is Tick => !!tick && !tick[1].isNaN() && !tick[2].isNaN()
+    )
     .map<[Tick, number]>((tick, index) => [tick, index])
     // sort by top to bottom: select ticks then shortest -> tallest ticks
     .sort(([a, aIndex], [b, bIndex]) => {


### PR DESCRIPTION
Ensure that just-removed ticks no longer break the SVG drawing by no longer drawing ticks of NaN height.