### PR TITLE
fix: add toasts for swap and liquidity pages

### DIFF
--- a/src/components/Notifications/Notifications.scss
+++ b/src/components/Notifications/Notifications.scss
@@ -7,6 +7,8 @@
     right: 0;
     display: flex;
     flex-direction: column;
+    // ensure notifications go above any page tricks
+    z-index: 11;
   }
 
   .notification {


### PR DESCRIPTION
Ensure notifications go above some absolute positioned page elements