### PR TITLE
fix: deposit amount normalization

### DIFF
--- a/src/pages/Pool/Pool.tsx
+++ b/src/pages/Pool/Pool.tsx
@@ -528,6 +528,8 @@ export default function Pool() {
               ? tokenAmountA
                   .multipliedBy(shapeFactor[index])
                   .multipliedBy(tick.reserveA)
+                  // normalize ticks to market value
+                  .multipliedBy(edgePrice || 1)
               : new BigNumber(0),
             reserveB: tickCounts[1]
               ? tokenAmountB


### PR DESCRIPTION
The amounts deposited in MsgDeposit txs are now normalized to the amount that was originally inputted by the user.

This leaves the userTicks in the LiquiditySelector component to be of arbitrary heights, and only the relative heights are meaningful. The userTicks heights are now used to represent current market value of the amounts inputted by the user.