### PR TITLE
feat: filter MyLiquidity ticks to each fee tier

### DIFF
--- a/src/components/LiquidityDistribution/LiquidityDistribution.tsx
+++ b/src/components/LiquidityDistribution/LiquidityDistribution.tsx
@@ -45,7 +45,6 @@ export default function LiquidityDistribution({
   canMoveUp,
   canMoveDown,
   canMoveX,
-  viewOnlyUserTicks,
 }: LiquiditySelectorProps & {
   chartTypeSelected: 'Orderbook' | 'AMM';
   tokenA: Token;
@@ -117,7 +116,6 @@ export default function LiquidityDistribution({
               canMoveUp={canMoveUp}
               canMoveDown={canMoveDown}
               canMoveX={canMoveX}
-              viewOnlyUserTicks={viewOnlyUserTicks}
             ></LiquiditySelector>
           </div>
         </div>

--- a/src/components/LiquiditySelector/LiquiditySelector.tsx
+++ b/src/components/LiquiditySelector/LiquiditySelector.tsx
@@ -37,7 +37,6 @@ export interface LiquiditySelectorProps {
   canMoveUp?: boolean;
   canMoveDown?: boolean;
   canMoveX?: boolean;
-  viewOnlyUserTicks?: boolean;
   oneSidedLiquidity?: boolean;
 }
 
@@ -101,7 +100,6 @@ export default function LiquiditySelector({
   canMoveUp,
   canMoveDown,
   canMoveX,
-  viewOnlyUserTicks = false,
   oneSidedLiquidity = false,
 }: LiquiditySelectorProps) {
   // translate ticks from token0/1 to tokenA/B
@@ -345,12 +343,6 @@ export default function LiquiditySelector({
       },
       undefined
     );
-    // if focusing on just the current tick price range
-    if (viewOnlyUserTicks && minUserTickPrice && maxUserTickPrice) {
-      setGraphStart(minUserTickPrice.multipliedBy(0.9));
-      setGraphEnd(maxUserTickPrice.dividedBy(0.9));
-      return;
-    }
     const allValues = [
       Number(rangeMin),
       Number(rangeMax),
@@ -373,7 +365,6 @@ export default function LiquiditySelector({
     rangeMin,
     rangeMax,
     userTicks,
-    viewOnlyUserTicks,
   ]);
 
   // calculate histogram values


### PR DESCRIPTION
The PR allows the MyLiquidity ticks to be filtered to each fee tier.

like so:
![Screenshot 2022-12-07 at 7 28 36 pm](https://user-images.githubusercontent.com/6194521/206141259-99bdd386-3ec8-4f9e-abc6-812b7fc46851.png)
![Screenshot 2022-12-07 at 7 29 22 pm](https://user-images.githubusercontent.com/6194521/206141291-4e36163e-3446-4b7a-9a35-dcad65d9cf3f.png)
![Screenshot 2022-12-07 at 7 29 00 pm](https://user-images.githubusercontent.com/6194521/206141333-8b69ceb6-c160-4b4f-90c8-83b2a3470b13.png)

the axis remains the same for every selected fee tier.

This filtering action means that a user can edit just the ticks belonging in one fee tier without editing the rest of the ticks.