### PR TITLE
feat: Add event listener to track Keplr account changes

### DIFF
--- a/src/lib/web3/useWeb3.tsx
+++ b/src/lib/web3/useWeb3.tsx
@@ -113,6 +113,18 @@ export function Web3Provider({ children }: Web3ContextProps) {
           }
         }
         setProvider(provider);
+        // add listener for Keplr state changes
+        window.addEventListener('keplr_keystorechange', async () => {
+          const offlineSigner = window.keplr.getOfflineSigner(chainId);
+          const accounts = await offlineSigner?.getAccounts();
+          setAddress((address) => {
+            // switch address or remove if already connected
+            if (address) {
+              return accounts[0]?.address || null;
+            }
+            return null;
+          });
+        });
       }
     }
     run();


### PR DESCRIPTION
The PR add an event listener to track Keplr account change. When the Keplr account is updated all pages react to the new information to show relevant data for that account.