### PR TITLE
fix: add testnet deployment specific build options

### DIFF
--- a/.env.development
+++ b/.env.development
@@ -1,3 +1,7 @@
 
 # Add prices for development tokens
 REACT_APP__DEV_TOKEN_DENOMS=['sdk.coin:token', 'sdk.coin:stake']
+
+# Override chain name
+REACT_APP__CHAIN_ID=duality-testnet-1
+REACT_APP__CHAIN_NAME=Duality testnet

--- a/.env.production
+++ b/.env.production
@@ -1,8 +1,3 @@
 
 REACT_APP__CHAIN_ID=duality-1
 REACT_APP__CHAIN_NAME=Duality mainnet
-
-# todo: when we release mainnet, we should chain the targeted chain settings
-REACT_APP__CHAIN_ID=duality-testnet-1
-REACT_APP__CHAIN_NAME=Duality testnet
-REACT_APP__DEV_TOKEN_DENOMS=['sdk.coin:token', 'sdk.coin:stake']

--- a/.github/workflows/deploy_semantic_release.yml
+++ b/.github/workflows/deploy_semantic_release.yml
@@ -85,6 +85,9 @@ jobs:
         with:
           node-version: ${{ steps.get-node-version.outputs.NODE_VERSION }}
 
+      - name: Add testnet specific environment settings over production settings
+        run: cp .env.development .env.local
+
       - name: Install dependencies
         run: npm ci
 


### PR DESCRIPTION
Fix https://app.dev.duality.xyz/ environment variables to be that of `.env.development` and not that of `.env.production`