### PR TITLE
fix: Make which token is which more obvious (part 2)

### DIFF
--- a/src/components/LiquidityDistribution/LiquidityDistribution.tsx
+++ b/src/components/LiquidityDistribution/LiquidityDistribution.tsx
@@ -72,7 +72,7 @@ export default function LiquidityDistribution({
             <h3 className="h3 text-normal">Liquidity Distribution</h3>
             <span className="tokens-badge badge-default badge-large font-console">
               {tokenA?.symbol}
-              <span className="mx-2">-</span>
+              <span className="mx-2">/</span>
               {tokenB?.symbol}
             </span>
             <button type="button" className="icon-button" onClick={swapAll}>
@@ -125,7 +125,7 @@ export default function LiquidityDistribution({
           </div>
           <div className="hero-texts mb-4">
             {currentPriceFromTicks
-              ? `${tokenB.display.toUpperCase()}/${tokenA.display.toUpperCase()}`
+              ? `${tokenA.display.toUpperCase()}/${tokenB.display.toUpperCase()}`
               : '-'}
           </div>
           <div>Current Price</div>

--- a/src/pages/Pool/Pool.tsx
+++ b/src/pages/Pool/Pool.tsx
@@ -817,7 +817,7 @@ export default function Pool() {
                 <h3 className="h3 text-normal">Liquidity Distribution</h3>
                 <span className="tokens-badge badge-default badge-large font-console">
                   {tokenA?.symbol}
-                  <span className="mx-2">-</span>
+                  <span className="mx-2">/</span>
                   {tokenB?.symbol}
                 </span>
                 <button type="button" className="icon-button" onClick={swapAll}>
@@ -854,7 +854,7 @@ export default function Pool() {
               </div>
               <div className="hero-texts mb-4">
                 {currentPriceFromTicks
-                  ? `${tokenB.display.toUpperCase()}/${tokenA.display.toUpperCase()}`
+                  ? `${tokenA.display.toUpperCase()}/${tokenB.display.toUpperCase()}`
                   : '-'}
               </div>
               <div>Current Price</div>


### PR DESCRIPTION
This PR fixes the visual representation of what token is in ratio to what token

add corrects a mistake in the previous PR:
- #220 