### PR TITLE
fix: input button styles on mobile 

### DIFF
--- a/src/styles/components/buttons.scss
+++ b/src/styles/components/buttons.scss
@@ -47,6 +47,11 @@ button,
   padding: 0;
 }
 
+input {
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  appearance: none;
+}
 input[type='submit'],
 button[type='submit'],
 .submit-button {


### PR DESCRIPTION
This PR fixes input button style on mobile browsers

iOS Safari "Add Liquidity" button fixed:
![Image](https://user-images.githubusercontent.com/6194521/207768493-c26a3896-7b43-4a12-ac39-e9dd932c79d1.jpg)
