### PR TITLE
style: improve token input styling part 2

### DIFF
--- a/src/components/TokenInputGroup/TokenInputGroup.tsx
+++ b/src/components/TokenInputGroup/TokenInputGroup.tsx
@@ -19,7 +19,6 @@ import './TokenInputGroup.scss';
 const { REACT_APP__MAX_FRACTION_DIGITS = '' } = process.env;
 const maxFractionDigits = parseInt(REACT_APP__MAX_FRACTION_DIGITS) || 20;
 
-const minSignificantDigits = 8;
 const maxSignificantDigits = 20;
 const placeholder = '...';
 
@@ -139,11 +138,7 @@ export default function TokenInputGroup({
       />
       <input
         type="text"
-        className={[
-          'token-group-input',
-          'ml-auto',
-          !Number(value) && 'input--zero',
-        ]
+        className={['token-group-input', !Number(value) && 'input--zero']
           .filter(Boolean)
           .join(' ')}
         value={value || placeholder}
@@ -153,10 +148,8 @@ export default function TokenInputGroup({
         disabled={disabledInput}
         style={useMemo(() => {
           return {
-            // set width of input based on current values but restrained to a min/max
-            minWidth: `${
-              minSignificantDigits + (value?.includes('.') ? 1 : 0)
-            }ch`,
+            // set width of input based on current values but restrained to max characters
+            minWidth: '100%',
             maxWidth: `${
               maxSignificantDigits + (value?.includes('.') ? 1 : 0)
             }ch`,


### PR DESCRIPTION
This PR fixes a few more token input group styling issues:
- input width is inconsistent between empty and non-empty values
- input width does not fill available space for component (the when clicking to input a value, the clickable area is not as large as expected)