### PR TITLE
fix: make number input controls more standard (part 2)

### DIFF
--- a/src/components/inputs/NumberInput/NumberInput.tsx
+++ b/src/components/inputs/NumberInput/NumberInput.tsx
@@ -30,7 +30,7 @@ const parseValue = (value: string, appendString = '') => {
 };
 
 function sanitizeInputRegex(string: string) {
-  // see https://github.com/sindresorhus/escape-string-regexp/blob/ba9a4473850cb367936417e97f1f2191b7cc67dd/index.js#L8-L10
+  // see https://github.com/sindresorhus/escape-string-regexp/blob/v5.0.0/index.js#L8-L10
   return string.replace(/[|\\{}()[\]^$+*?.]/g, '\\$&').replace(/-/g, '\\x2d');
 }
 


### PR DESCRIPTION
Fixes:
- https://github.com/duality-labs/duality-web-app/pull/253

Add santized appendString to expected NumberInput pattern. 

The pattern given to number input was failing Chrome browser validation when the appendString % is added:
![Screenshot 2023-01-09 at 2 44 11 pm](https://user-images.githubusercontent.com/6194521/211242410-d45a4bf8-2792-4370-a08b-62305882412e.png)
