### PR TITLE
refactor: optimize liquidity map calculation

### DIFF
--- a/src/lib/web3/indexerProvider.tsx
+++ b/src/lib/web3/indexerProvider.tsx
@@ -27,12 +27,12 @@ import {
   addressableTokenMap as tokenMap,
   Token,
 } from '../../components/TokenPicker/hooks';
-import { FeeType, feeTypes } from './utils/fees';
+import { feeTypes } from './utils/fees';
 import { getAmountInDenom } from './utils/tokens';
 
 const { REACT_APP__REST_API } = process.env;
 
-type TokenAddress = string; // a valid hex address, eg. 0x01
+export type TokenAddress = string; // a valid hex address, eg. 0x01
 
 interface BalancesResponse {
   balances?: Coin[];
@@ -686,61 +686,6 @@ export function useIndexerPairData(
       : undefined;
   return {
     data: pair,
-    error,
-    isValidating,
-  };
-}
-
-export function useFeeLiquidityMap(
-  tokenA?: TokenAddress,
-  tokenB?: TokenAddress
-) {
-  const {
-    data: pair,
-    isValidating,
-    error,
-  } = useIndexerPairData(tokenA, tokenB);
-  const feeLiquidityMap = useMemo(() => {
-    if (!pair) return;
-
-    const ticks = Object.values(pair.ticks);
-    const feeTypeLiquidity = feeTypes.reduce<Record<FeeType['fee'], BigNumber>>(
-      (result, feeType) => {
-        result[feeType.fee] = new BigNumber(0);
-        return result;
-      },
-      {}
-    );
-
-    const feeSharesMap = ticks.reduce<{ [feeTier: string]: BigNumber }>(
-      (result, { fee, totalShares }) => {
-        if (totalShares.isGreaterThan(0)) {
-          const feeString = fee.toFixed();
-          result[feeString] = result[feeString].plus(totalShares);
-        }
-        return result;
-      },
-      feeTypeLiquidity
-    );
-
-    const totalLiquidity = Object.values(feeSharesMap).reduce<BigNumber>(
-      (total, shares) => {
-        return total.plus(shares);
-      },
-      new BigNumber(0)
-    );
-
-    // normalize shares to a percentage
-    return Object.entries(feeSharesMap).reduce<{
-      [feeTier: string]: BigNumber;
-    }>((result, [feeString, shares]) => {
-      result[feeString] = shares.dividedBy(totalLiquidity);
-      return result;
-    }, feeTypeLiquidity);
-  }, [pair]);
-
-  return {
-    data: feeLiquidityMap,
     error,
     isValidating,
   };

--- a/src/pages/Pool/Pool.tsx
+++ b/src/pages/Pool/Pool.tsx
@@ -20,7 +20,6 @@ import {
   getBalance,
   TickInfo,
   useBankBalances,
-  useFeeLiquidityMap,
   useIndexerPairData,
 } from '../../lib/web3/indexerProvider';
 import { useHasPriceData } from '../../lib/tokenPrices';
@@ -39,6 +38,7 @@ import RadioButtonGroupInput from '../../components/RadioButtonGroupInput/RadioB
 
 import { useTokens, Token } from '../../components/TokenPicker/hooks';
 import { useDeposit } from './useDeposit';
+import useFeeLiquidityMap from './useFeeLiquidityMap';
 
 import { formatPrice } from '../../lib/utils/number';
 import { priceToTickIndex } from '../../lib/web3/utils/ticks';

--- a/src/pages/Pool/useFeeLiquidityMap.ts
+++ b/src/pages/Pool/useFeeLiquidityMap.ts
@@ -1,0 +1,63 @@
+import { useMemo } from 'react';
+import BigNumber from 'bignumber.js';
+
+import {
+  TokenAddress,
+  useIndexerPairData,
+} from '../../lib/web3/indexerProvider';
+import { FeeType, feeTypes } from '../../lib/web3/utils/fees';
+
+export default function useFeeLiquidityMap(
+  tokenA?: TokenAddress,
+  tokenB?: TokenAddress
+) {
+  const {
+    data: pair,
+    isValidating,
+    error,
+  } = useIndexerPairData(tokenA, tokenB);
+  const feeLiquidityMap = useMemo(() => {
+    if (!pair) return;
+
+    const ticks = Object.values(pair.ticks);
+    const feeTypeLiquidity = feeTypes.reduce<Record<FeeType['fee'], BigNumber>>(
+      (result, feeType) => {
+        result[feeType.fee] = new BigNumber(0);
+        return result;
+      },
+      {}
+    );
+
+    const feeSharesMap = ticks.reduce<{ [feeTier: string]: BigNumber }>(
+      (result, { fee, totalShares }) => {
+        if (totalShares.isGreaterThan(0)) {
+          const feeString = fee.toFixed();
+          result[feeString] = result[feeString].plus(totalShares);
+        }
+        return result;
+      },
+      feeTypeLiquidity
+    );
+
+    const totalLiquidity = Object.values(feeSharesMap).reduce<BigNumber>(
+      (total, shares) => {
+        return total.plus(shares);
+      },
+      new BigNumber(0)
+    );
+
+    // normalize shares to a percentage
+    return Object.entries(feeSharesMap).reduce<{
+      [feeTier: string]: BigNumber;
+    }>((result, [feeString, shares]) => {
+      result[feeString] = shares.dividedBy(totalLiquidity);
+      return result;
+    }, feeTypeLiquidity);
+  }, [pair]);
+
+  return {
+    data: feeLiquidityMap,
+    error,
+    isValidating,
+  };
+}


### PR DESCRIPTION
Potentially made the calculation of liquidity percentage in each fee tier a bit quicker. 

Also reorganized the hook into its own file as it was only being used on one page.