### PR TITLE
docs: add current version of the backend into the ReadMe file

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 The code for the Duality front-end web app.
 
-This version of the front end is intended to work with release v0.1.0 of the backend:
+This version of the front end is intended to work with this release of the backend:
 
 - https://github.com/duality-labs/duality/releases/tag/v0.1.0
 


### PR DESCRIPTION
This is the current used version since release v0.1.58
- https://github.com/duality-labs/duality-web-app/releases/tag/v0.1.58
- https://github.com/duality-labs/duality-web-app/pull/173

before that the FE was developed against an unreleased Cosmos backend branch
- https://github.com/duality-labs/duality/commit/0768dd558be035323efcd8934f0561398c020a84
- https://github.com/duality-labs/duality-web-app/pull/102

and before that the FE was developed against an Ethereum chain on a different unreleased prototype repository