### PR TITLE
fix: shares from reserves calculation

### DIFF
--- a/src/lib/web3/utils/ticks.ts
+++ b/src/lib/web3/utils/ticks.ts
@@ -21,5 +21,5 @@ export function calculateShares({
   reserve0?: TickInfo['reserve0'];
   reserve1?: TickInfo['reserve1'];
 }): BigNumber {
-  return reserve0.plus(reserve1.dividedBy(price));
+  return reserve0.plus(reserve1.multipliedBy(price));
 }


### PR DESCRIPTION
This error was introduced in:
- https://github.com/duality-labs/duality-web-app/pull/275

From depositing ~equal amounts of tokens to each side the MyLiquidity UI went from previously: 
![Screenshot 2023-01-15 at 4 45 53 am](https://user-images.githubusercontent.com/6194521/212490937-1aaed655-db62-4289-b01c-e38ca5793e19.png)

to the correct: 
![Screenshot 2023-01-15 at 4 46 02 am](https://user-images.githubusercontent.com/6194521/212490946-0d537c40-1774-4246-87fb-6cc5708ee68d.png)
