### PR TITLE
docs: better instructions for upgrade API to v0.1.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,9 +7,12 @@ This version of the front end is intended to work with this release of the backe
 - Release [v0.1.2] https://github.com/duality-labs/duality/releases/tag/v0.1.2
 - run with Docker:
   - checkout tag [v0.1.2](https://github.com/duality-labs/duality/releases/tag/v0.1.2) (commit [5051af9](https://github.com/duality-labs/duality/commit/5051af98fb0db8eefcd3a2d546e5a5a44ae9ee65))
+  - `$ docker build . -t localnet`
+  - `$ docker run -it --rm -p 26657:26657 -p 1317:1317 -e MODE=new localnet`
 - run with Docker Compose:
   - checkout [4dd6d4b](https://github.com/duality-labs/duality/commit/4dd6d4b4e289cd7cc99fd8f459a7c938bff154e3) part of Docker Compose setup
   - merge [v0.1.2](https://github.com/duality-labs/duality/tree/v0.1.2) or [5051af9](https://github.com/duality-labs/duality/commit/5051af98fb0db8eefcd3a2d546e5a5a44ae9ee65)
+  - `$ docker-compose ...` (see Docker Compose setup section below)
 
 ## Setting up the dev environment
 


### PR DESCRIPTION
The PR hopes to make it clearer what version of the API the front end should connect to and how to run that version locally with Docker.