### PR TITLE
feat: add datazoom visual to liquidity chart

### DIFF
--- a/src/components/LiquiditySelector/LiquiditySelector.scss
+++ b/src/components/LiquiditySelector/LiquiditySelector.scss
@@ -173,3 +173,18 @@
     fill: hsl(165, 83%, 57%);
   }
 }
+
+.data-zoom {
+  .data-zoom-area {
+    fill: hsla(220, 44%, 45%, 0.1);
+    stroke-width: 1;
+    stroke: hsla(220, 44%, 45%, 0.6);
+  }
+  .data-zoom-range-area {
+    fill: hsla(220, 44%, 45%, 0.5);
+    stroke-width: 0;
+  }
+  .data-zoom-data {
+    stroke: var(--text-default);
+  }
+}

--- a/src/components/LiquiditySelector/LiquiditySelector.scss
+++ b/src/components/LiquiditySelector/LiquiditySelector.scss
@@ -187,7 +187,8 @@
   .data-zoom-data {
     rect {
       fill: white;
-      stroke-width: 0;
+      stroke-width: 0.25;
+      stroke: white;
     }
   }
 }

--- a/src/components/LiquiditySelector/LiquiditySelector.scss
+++ b/src/components/LiquiditySelector/LiquiditySelector.scss
@@ -181,14 +181,18 @@
     stroke: hsla(220, 44%, 45%, 0.6);
   }
   .data-zoom-range-area {
-    fill: hsla(220, 44%, 45%, 0.5);
     stroke-width: 0;
+  }
+  .data-zoom-range-flag {
+    fill: hsla(165, 83%, 57%, 1);
   }
   .data-zoom-data {
     rect {
       fill: hsl(202deg, 58%, 33%);
       stroke-width: 0.5;
       stroke: hsl(202deg, 58%, 33%);
+      opacity: 1;
+      cursor: default;
     }
   }
 }

--- a/src/components/LiquiditySelector/LiquiditySelector.scss
+++ b/src/components/LiquiditySelector/LiquiditySelector.scss
@@ -186,9 +186,9 @@
   }
   .data-zoom-data {
     rect {
-      fill: white;
-      stroke-width: 0.25;
-      stroke: white;
+      fill: hsl(202deg, 58%, 33%);
+      stroke-width: 0.5;
+      stroke: hsl(202deg, 58%, 33%);
     }
   }
 }

--- a/src/components/LiquiditySelector/LiquiditySelector.scss
+++ b/src/components/LiquiditySelector/LiquiditySelector.scss
@@ -185,6 +185,9 @@
     stroke-width: 0;
   }
   .data-zoom-data {
-    stroke: var(--text-default);
+    rect {
+      fill: white;
+      stroke-width: 0;
+    }
   }
 }

--- a/src/components/LiquiditySelector/LiquiditySelector.tsx
+++ b/src/components/LiquiditySelector/LiquiditySelector.tsx
@@ -542,7 +542,6 @@ export default function LiquiditySelector({
     },
     [graphHeight, containerSize.height]
   );
-  // eslint-disable-next-line
   const plotYDataZoom = useCallback(
     (yValue: BigNumber.Value): number => {
       const y = new BigNumber(yValue).toNumber();
@@ -721,7 +720,20 @@ export default function LiquiditySelector({
         rangeMin={rangeMin}
         rangeMax={rangeMax}
         plotX={plotXDataZoom}
-      />
+      >
+        <TickBucketsGroup
+          className="left-ticks"
+          tickBuckets={feeTickBuckets[0]}
+          plotX={plotXDataZoom}
+          plotY={plotYDataZoom}
+        />
+        <TickBucketsGroup
+          className="right-ticks"
+          tickBuckets={feeTickBuckets[1]}
+          plotX={plotXDataZoom}
+          plotY={plotYDataZoom}
+        />
+      </DataZoom>
     </svg>
   );
 
@@ -1745,6 +1757,7 @@ function DataZoom({
   rangeMin,
   rangeMax,
   className,
+  children,
 }: {
   currentPrice: BigNumber | undefined;
   plotX: (x: BigNumber.Value) => number;
@@ -1755,6 +1768,7 @@ function DataZoom({
   rangeMin: string;
   rangeMax: string;
   className?: string;
+  children?: React.ReactNode;
 }) {
   return (
     <g className={['data-zoom', className].filter(Boolean).join(' ')}>
@@ -1772,15 +1786,7 @@ function DataZoom({
         y={-dataZoomHeight}
         height={dataZoomHeight - 1}
       />
-      {dataStart && dataEnd && (
-        <rect
-          className="data-zoom-area data-zoom-data"
-          x={plotX(dataStart)}
-          width={plotX(dataEnd) - plotX(dataStart)}
-          y={-dataZoomHeight / 2}
-          height={dataZoomHeight / 2 - 1}
-        />
-      )}
+      <g className="data-zoom-data">{children}</g>
     </g>
   );
 }

--- a/src/components/LiquiditySelector/LiquiditySelector.tsx
+++ b/src/components/LiquiditySelector/LiquiditySelector.tsx
@@ -1835,6 +1835,20 @@ function DataZoom({
         height={dataZoomHeight - 1}
       />
       <g className="data-zoom-data">{children}</g>
+      <rect
+        className="data-zoom-range-flag data-zoom-range-start"
+        x={plotX(rangeMin) - 4}
+        width={4}
+        y={-dataZoomHeight}
+        height={dataZoomHeight - 1}
+      />
+      <rect
+        className="data-zoom-range-flag data-zoom-range-end"
+        x={plotX(rangeMax)}
+        width={4}
+        y={-dataZoomHeight}
+        height={dataZoomHeight - 1}
+      />
     </g>
   );
 }

--- a/src/components/LiquiditySelector/LiquiditySelector.tsx
+++ b/src/components/LiquiditySelector/LiquiditySelector.tsx
@@ -511,7 +511,7 @@ export default function LiquiditySelector({
   }, [emptyBuckets, allTicks]);
 
   const dataZoomEmptyBuckets = useMemo(() => {
-    return getEmptyBuckets(dataZoomViewableStart, dataZoomViewableEnd, 1.75);
+    return getEmptyBuckets(dataZoomViewableStart, dataZoomViewableEnd);
   }, [getEmptyBuckets, dataZoomViewableStart, dataZoomViewableEnd]);
 
   const dataZoomFeeTickBuckets = useMemo<

--- a/src/components/LiquiditySelector/LiquiditySelector.tsx
+++ b/src/components/LiquiditySelector/LiquiditySelector.tsx
@@ -609,7 +609,7 @@ export default function LiquiditySelector({
       const height = dataZoomHeight;
       return dataZoomGraphHeight === 0
         ? 0
-        : 0 - (height * y) / dataZoomGraphHeight;
+        : -3 - ((height - 6) * y) / dataZoomGraphHeight;
     },
     [dataZoomGraphHeight]
   );
@@ -1836,23 +1836,23 @@ function DataZoom({
         className="data-zoom-area data-zoom-range-area"
         x={plotX(rangeMin)}
         width={plotX(rangeMax) - plotX(rangeMin)}
-        y={-dataZoomHeight}
-        height={dataZoomHeight - 1}
+        y={-(dataZoomHeight - 2)}
+        height={dataZoomHeight - 2 - 1}
       />
       <g className="data-zoom-data">{children}</g>
       <rect
         className="data-zoom-range-flag data-zoom-range-start"
         x={plotX(rangeMin) - 4}
         width={4}
-        y={-dataZoomHeight}
-        height={dataZoomHeight - 1}
+        y={-(dataZoomHeight - 0)}
+        height={dataZoomHeight - 0 - 1}
       />
       <rect
         className="data-zoom-range-flag data-zoom-range-end"
         x={plotX(rangeMax)}
         width={4}
-        y={-dataZoomHeight}
-        height={dataZoomHeight - 1}
+        y={-(dataZoomHeight - 0)}
+        height={dataZoomHeight - 0 - 1}
       />
     </g>
   );

--- a/src/components/LiquiditySelector/LiquiditySelector.tsx
+++ b/src/components/LiquiditySelector/LiquiditySelector.tsx
@@ -420,10 +420,11 @@ export default function LiquiditySelector({
     (
       // get bounds
       xMin: BigNumber,
-      xMax: BigNumber
+      xMax: BigNumber,
+      bucketWidth?: number
     ) => [TickGroupBucketsEmpty, TickGroupBucketsEmpty]
   >(
-    (xMin, xMax) => {
+    (xMin, xMax, xbucketWidth = bucketWidth) => {
       // get middle 'break' point which will separate bucket sections
       const breakPoint = edgePrice || currentPriceFromTicks;
       // skip if there is no breakpoint
@@ -439,7 +440,7 @@ export default function LiquiditySelector({
 
       // estimate number of buckets needed
       const bucketCount =
-        (Math.ceil(containerSize.width / bucketWidth) ?? 1) + // default to 1 bucket if none
+        (Math.ceil(containerSize.width / xbucketWidth) ?? 1) + // default to 1 bucket if none
         (currentPriceIsWithinView ? 1 : 0); // add bucket to account for splitting bucket on current price within view
 
       // find number of indexes on each side to show
@@ -510,7 +511,7 @@ export default function LiquiditySelector({
   }, [emptyBuckets, allTicks]);
 
   const dataZoomEmptyBuckets = useMemo(() => {
-    return getEmptyBuckets(dataZoomViewableStart, dataZoomViewableEnd);
+    return getEmptyBuckets(dataZoomViewableStart, dataZoomViewableEnd, 1.75);
   }, [getEmptyBuckets, dataZoomViewableStart, dataZoomViewableEnd]);
 
   const dataZoomFeeTickBuckets = useMemo<

--- a/src/lib/web3/utils/ticks.ts
+++ b/src/lib/web3/utils/ticks.ts
@@ -5,9 +5,12 @@ export function tickIndexToPrice(tickIndex: BigNumber): BigNumber {
   return new BigNumber(Math.pow(1.0001, tickIndex.toNumber()));
 }
 
-export function priceToTickIndex(price: BigNumber): BigNumber {
+export function priceToTickIndex(
+  price: BigNumber,
+  roundingMethod = 'round' as 'round' | 'ceil' | 'floor'
+): BigNumber {
   return new BigNumber(
-    Math.round(Math.log(price.toNumber()) / Math.log(1.0001))
+    Math[roundingMethod](Math.log(price.toNumber()) / Math.log(1.0001))
   );
 }
 

--- a/src/pages/Pool/Pool.tsx
+++ b/src/pages/Pool/Pool.tsx
@@ -886,6 +886,8 @@ function Pool() {
                 <LiquiditySelector
                   tokenA={tokenA}
                   tokenB={tokenB}
+                  rangeMinLimit={pairPriceMin}
+                  rangeMaxLimit={pairPriceMax}
                   rangeMin={rangeMin}
                   rangeMax={rangeMax}
                   setRangeMin={setRangeMin}

--- a/src/pages/Pool/Pool.tsx
+++ b/src/pages/Pool/Pool.tsx
@@ -187,9 +187,14 @@ function Pool() {
         : [priceMin, priceMax],
     [currentPriceFromTicks]
   );
+
+  // allow range flags to be outside of the view sometimes
+  const [containRangeInView, setContainRangeInView] = useState(true);
+
   // protect price range extents
   const setRangeMin = useCallback<React.Dispatch<React.SetStateAction<string>>>(
     (valueOrCallback) => {
+      setContainRangeInView(true);
       const restrictValue = (value: string) => {
         return restrictPriceRangeValues(value, [pairPriceMin, pairPriceMax]);
       };
@@ -206,6 +211,7 @@ function Pool() {
   );
   const setRangeMax = useCallback<React.Dispatch<React.SetStateAction<string>>>(
     (valueOrCallback) => {
+      setContainRangeInView(true);
       const restrictValue = (value: string) => {
         return restrictPriceRangeValues(value, [pairPriceMin, pairPriceMax]);
       };
@@ -903,6 +909,8 @@ function Pool() {
                   canMoveDown
                   canMoveX
                   oneSidedLiquidity={isValueAZero || isValueBZero}
+                  containRangeInView={containRangeInView}
+                  setContainRangeInView={setContainRangeInView}
                   ControlsComponent={ChartControls}
                 ></LiquiditySelector>
               </div>

--- a/src/pages/Pool/useDeposit.ts
+++ b/src/pages/Pool/useDeposit.ts
@@ -15,7 +15,11 @@ import {
 } from '../../components/Notifications/common';
 import { getAmountInDenom } from '../../lib/web3/utils/tokens';
 import { readEvents } from '../../lib/web3/utils/txs';
-import { getPairID, useIndexerData } from '../../lib/web3/indexerProvider';
+import {
+  getPairID,
+  hasMatchingPairOfOrder,
+  useIndexerData,
+} from '../../lib/web3/indexerProvider';
 import { getVirtualTickIndexes } from '../MyLiquidity/useShareValueMap';
 
 interface SendDepositResponse {
@@ -34,8 +38,7 @@ export function useDeposit(): [
     tokenA: Token | undefined,
     tokenB: Token | undefined,
     fee: BigNumber | undefined,
-    userTicks: TickGroup,
-    invertedOrder?: boolean
+    userTicks: TickGroup
   ) => Promise<void>
 ] {
   // get previous ticks context
@@ -51,8 +54,7 @@ export function useDeposit(): [
       tokenA: Token | undefined,
       tokenB: Token | undefined,
       fee: BigNumber | undefined,
-      userTicks: TickGroup,
-      invertedOrder = false
+      userTicks: TickGroup
     ) {
       try {
         // check for correct inputs
@@ -65,6 +67,36 @@ export function useDeposit(): [
         }
         if (!fee || !fee.isGreaterThanOrEqualTo(0)) {
           throw new Error('Fee not set');
+        }
+
+        // do not make requests if they are not routable
+        if (!tokenA.address) {
+          throw new Error(
+            `Token ${tokenA.symbol} has no address on the Duality chain`
+          );
+        }
+        if (!tokenB.address) {
+          throw new Error(
+            `Token ${tokenB.symbol} has no address on the Duality chain`
+          );
+        }
+
+        const forward = pairs?.[getPairID(tokenA.address, tokenB.address)];
+        const reverse = pairs?.[getPairID(tokenB.address, tokenA.address)];
+        const pairTicks = (forward || reverse)?.ticks;
+
+        if (!pairs || !pairTicks) {
+          throw new Error(
+            `Cannot initialize a new pair here: ${[
+              `our calculation of pair ID as either "${getPairID(
+                tokenA.address,
+                tokenB.address
+              )}" or "${getPairID(
+                tokenB.address,
+                tokenA.address
+              )}" may be incorrect.`,
+            ].join(', ')}`
+          );
         }
 
         // check all user ticks and filter to non-zero ticks
@@ -85,6 +117,56 @@ export function useDeposit(): [
               throw new Error('Amounts not set');
             }
             return reserveA.isGreaterThan(0) || reserveB.isGreaterThan(0);
+          })
+          // convert virtual (indexer) Ticks into "real" index Ticks (which are expected in the API)
+          .flatMap((tick) => {
+            const hasA = tick.reserveA.isGreaterThan(0);
+            const hasB = tick.reserveB.isGreaterThan(0);
+
+            // the order of tick indexes appears reversed here because we are
+            // converting from virtual to real ticks (not real to virual)
+            const [tickIndex1, tickIndex0] = getVirtualTickIndexes(
+              tick.tickIndex,
+              tick.feeIndex
+            );
+
+            if (tickIndex0 === undefined || tickIndex1 === undefined) {
+              return [];
+            }
+
+            const [forward] = hasMatchingPairOfOrder(
+              pairs,
+              tick.tokenA.address || '',
+              tick.tokenB.address || ''
+            );
+
+            const ticks: TickGroup = [];
+
+            // add reserveA as a single tick
+            if (hasA) {
+              ticks.push({
+                ...tick,
+                // tick indexes must be in form of "token0/1" not "tokenA/B":
+                // we invert the indexes because we work with price1to0
+                // and the backend works on the basis of price0to1
+                tickIndex: forward ? -tickIndex0 : -tickIndex1,
+                reserveB: new BigNumber(0),
+              });
+            }
+
+            // add reserveB as a single tick
+            if (hasB) {
+              ticks.push({
+                ...tick,
+                // tick indexes must be in form of "token0/1" not "tokenA/B":
+                // we invert the indexes because we work with price1to0
+                // and the backend works on the basis of price0to1
+                tickIndex: forward ? -tickIndex1 : -tickIndex0,
+                reserveA: new BigNumber(0),
+              });
+            }
+
+            return ticks;
           })
           .reduce<TickGroup>((ticks, tick) => {
             // find equivalent tick
@@ -122,37 +204,23 @@ export function useDeposit(): [
         setIsValidating(true);
         setError(undefined);
 
-        // do not make requests if they are not routable
-        if (!tokenA.address) {
-          throw new Error(
-            `Token ${tokenA.symbol} has no address on the Duality chain`
-          );
-        }
-        if (!tokenB.address) {
-          throw new Error(
-            `Token ${tokenB.symbol} has no address on the Duality chain`
-          );
-        }
-        const forward = pairs?.[getPairID(tokenA.address, tokenB.address)];
-        const reverse = pairs?.[getPairID(tokenB.address, tokenA.address)];
-        const pairTicks = (forward || reverse)?.ticks;
         const gasEstimate = filteredUserTicks.reduce((gasEstimate, tick) => {
           const [tickIndex0, tickIndex1] = getVirtualTickIndexes(
             tick.tickIndex,
             tick.feeIndex
           );
           const existingTick =
-            tickIndex0 && tickIndex1
-              ? pairTicks?.find((pairTick) => {
-                  return (
-                    pairTick.tickIndex.isEqualTo(tickIndex0) ||
-                    pairTick.tickIndex.isEqualTo(tickIndex1)
-                  );
+            pairTicks && tickIndex0 !== undefined && tickIndex1 !== undefined
+              ? !!pairTicks.find((pairTick) => {
+                  return pairTick.tickIndex.isEqualTo(tickIndex0);
+                }) &&
+                !!pairTicks.find((pairTick) => {
+                  return pairTick.tickIndex.isEqualTo(tickIndex1);
                 })
               : undefined;
-          // add 50000 for existing ticks
+          // add 60000 for existing ticks
           // add 50000 more for initializing a new tick
-          return gasEstimate + (existingTick ? 50000 : 100000);
+          return gasEstimate + (existingTick ? 60000 : 100000);
           // add 80000 base gas
           // add 60000 for initilizing a new tick pair
         }, 80000 + (!pairTicks ? 60000 : 0));
@@ -172,11 +240,10 @@ export function useDeposit(): [
                   tokenA: tokenA.address,
                   tokenB: tokenB.address,
                   receiver: web3Address,
-                  // tick indexes must be in the form of "token0/1 index"
+                  // note: tick indexes must be in the form of "token0/1 index"
                   // not "tokenA/B" index, so inverted order indexes should be reversed
-                  tickIndexes: filteredUserTicks.map(
-                    (tick) => tick.tickIndex * (!invertedOrder ? -1 : 1)
-                  ),
+                  // check this commit for changes if this behavior changes
+                  tickIndexes: filteredUserTicks.map((tick) => tick.tickIndex),
                   feeIndexes: filteredUserTicks.map((tick) => tick.feeIndex),
                   amountsA: filteredUserTicks.map(
                     ({ reserveA }) =>


### PR DESCRIPTION
example of work so far:
![0da5dbaa-9377e2ef--graceful-palmier-ff28ba netlify app_liquidity(FullHD) (2)](https://user-images.githubusercontent.com/6194521/230322022-fd8bfabc-4cb2-4d3b-908e-ce549f29078d.png)

zoomed past selected range:
![0da5dbaa-9377e2ef--graceful-palmier-ff28ba netlify app_liquidity(FullHD) (3)](https://user-images.githubusercontent.com/6194521/230322099-b85fd0fa-8dfc-41fb-87bd-71ca96215d0a.png)
