### PR TITLE
refactor: upgrade api to backend v0.1.3 (part 1)

### DIFF
--- a/src/components/LiquiditySelector/useCurrentPriceFromTicks.ts
+++ b/src/components/LiquiditySelector/useCurrentPriceFromTicks.ts
@@ -22,13 +22,17 @@ function useMidTickIndexFromTicks(
   tokenA?: string,
   tokenB?: string
 ): number | undefined {
-  const { data: { ticks = [], token0, token1 } = {} } = useIndexerPairData(
-    tokenA,
-    tokenB
-  );
+  const {
+    data: {
+      token0Ticks: [token0Tick] = [],
+      token1Ticks: [token1Tick] = [],
+      token0,
+      token1,
+    } = {},
+  } = useIndexerPairData(tokenA, tokenB);
 
   // skip if there are no ticks to gain insight from
-  if (!ticks.length) {
+  if (!token0Tick && !token1Tick) {
     return;
   }
 
@@ -40,38 +44,12 @@ function useMidTickIndexFromTicks(
     return;
   }
 
-  const sortedTicks = ticks
-    // ignore irrelevant ticks
-    .filter((tick) => !tick.reserve0.isZero() || !tick.reserve1.isZero())
-    // ensure ticks are sorted
-    .sort((a, b) => a.tickIndex.comparedTo(b.tickIndex));
-
-  const highestTick0 = sortedTicks.reduceRight<TickInfo | undefined>(
-    (result, tick) => {
-      if (result === undefined && tick.reserve0.isGreaterThan(0)) {
-        return tick;
-      }
-      return result;
-    },
-    undefined
-  );
-
-  const lowestTick1 = sortedTicks.reduce<TickInfo | undefined>(
-    (result, tick) => {
-      if (result === undefined && tick.reserve1.isGreaterThan(0)) {
-        return tick;
-      }
-      return result;
-    },
-    undefined
-  );
-
   const midTickIndex =
-    highestTick0 && lowestTick1
+    token0Tick && token1Tick
       ? // calculate mid point
-        getMidIndex(highestTick0, lowestTick1)
+        getMidIndex(token0Tick, token1Tick)
       : // or return only found side of liquidity
-        highestTick0?.tickIndex ?? lowestTick1?.tickIndex;
+        token0Tick?.tickIndex ?? token1Tick?.tickIndex;
 
   return (reverse ? midTickIndex?.negated() : midTickIndex)?.toNumber();
 
@@ -84,19 +62,8 @@ function useMidTickIndexFromTicks(
       return highestTick0.tickIndex;
     }
     // linearly interpolate an answer
-    // get weights of each side in terms of token0 units
-    const highestTick0Value = sortedTicks
-      .filter((tick) => tick.tickIndex.isEqualTo(highestTick0.tickIndex))
-      .reduce((result, tick) => {
-        return result.plus(tick.reserve0);
-      }, new BigNumber(0))
-      .dividedBy(Math.pow(1.0001, highestTick0.tickIndex.toNumber()));
-    const lowestTick1Value = sortedTicks
-      .filter((tick) => tick.tickIndex.isEqualTo(lowestTick1.tickIndex))
-      .reduce((result, tick) => {
-        return result.plus(tick.reserve1);
-      }, new BigNumber(0))
-      .multipliedBy(Math.pow(1.0001, lowestTick1.tickIndex.toNumber()));
+    const highestTick0Value = highestTick0.reserve0;
+    const lowestTick1Value = lowestTick1.reserve1;
     // calculate the mid point
     const linearPercentage = lowestTick1Value.dividedBy(
       highestTick0Value.plus(lowestTick1Value)

--- a/src/pages/MyLiquidity/useShareValueMap.ts
+++ b/src/pages/MyLiquidity/useShareValueMap.ts
@@ -75,7 +75,6 @@ export default function useShareValueMap() {
             ? [tokenB, tokenA]
             : [tokenA, tokenB];
           const extendedShare: ShareValue = { share, token0, token1 };
-          const ticks = indexer[pairId]?.ticks || [];
           const [tickIndex1, tickIndex0] = getVirtualTickIndexes(
             tickIndex,
             feeIndex
@@ -83,12 +82,12 @@ export default function useShareValueMap() {
           if (tickIndex0 === undefined || tickIndex1 === undefined) {
             return result;
           }
-          const tick0 = ticks.find(
+          const tick0 = (indexer[pairId]?.token0Ticks || []).find(
             (tick) =>
               tick.feeIndex.isEqualTo(feeIndex) &&
               tick.tickIndex.isEqualTo(tickIndex0)
           );
-          const tick1 = ticks.find(
+          const tick1 = (indexer[pairId]?.token1Ticks || []).find(
             (tick) =>
               tick.feeIndex.isEqualTo(feeIndex) &&
               tick.tickIndex.isEqualTo(tickIndex1)

--- a/src/pages/Pool/useDeposit.ts
+++ b/src/pages/Pool/useDeposit.ts
@@ -135,19 +135,19 @@ export function useDeposit(): [
         }
         const forward = pairs?.[getPairID(tokenA.address, tokenB.address)];
         const reverse = pairs?.[getPairID(tokenB.address, tokenA.address)];
-        const pairTicks = (forward || reverse)?.ticks;
+        const pairTicks = forward || reverse;
         const gasEstimate = filteredUserTicks.reduce((gasEstimate, tick) => {
           const [tickIndex0, tickIndex1] = getVirtualTickIndexes(
             tick.tickIndex,
             tick.feeIndex
           );
           const existingTick =
-            tickIndex0 && tickIndex1
-              ? pairTicks?.find((pairTick) => {
-                  return (
-                    pairTick.tickIndex.isEqualTo(tickIndex0) ||
-                    pairTick.tickIndex.isEqualTo(tickIndex1)
-                  );
+            pairTicks && tickIndex0 !== undefined && tickIndex1 !== undefined
+              ? !!pairTicks.token0Ticks.find((pairTick) => {
+                  return pairTick.tickIndex.isEqualTo(tickIndex0);
+                }) &&
+                !!pairTicks.token1Ticks.find((pairTick) => {
+                  return pairTick.tickIndex.isEqualTo(tickIndex1);
                 })
               : undefined;
           // add 50000 for existing ticks

--- a/src/pages/Pool/useFeeLiquidityMap.ts
+++ b/src/pages/Pool/useFeeLiquidityMap.ts
@@ -20,7 +20,7 @@ export default function useFeeLiquidityMap(
   const feeLiquidityMap = useMemo(() => {
     if (!pair) return;
 
-    const ticks = Object.values(pair.ticks);
+    const ticks = pair.token0Ticks.concat(pair.token1Ticks);
     const feeTypeLiquidity = feeTypes.reduce<Record<FeeType['fee'], BigNumber>>(
       (result, feeType) => {
         result[feeType.fee] = new BigNumber(0);

--- a/src/pages/Swap/Swap.tsx
+++ b/src/pages/Swap/Swap.tsx
@@ -137,7 +137,9 @@ function Swap() {
             routerResult.tickIndexIn.negated().toNumber(),
             routerResult.tickIndexOut.negated().toNumber()
           );
-        const { ticks, token0 } = pair || {};
+        const { token0Ticks, token1Ticks, token0 } = pair || {};
+        const forward = result.tokenIn === token0;
+        const ticks = forward ? token1Ticks : token0Ticks;
         const ticksPassed =
           (tickMin !== undefined &&
             tickMax !== undefined &&
@@ -148,7 +150,6 @@ function Swap() {
               );
             })) ||
           [];
-        const forward = result.tokenIn === token0;
         const ticksUsed =
           ticksPassed?.filter(
             forward


### PR DESCRIPTION
In preparation for changes within v0.1.3, this PR updates how ticks are stored in the persistent state of the indexer.

Instead of storing all ticks of a pair as one list they will now stored as two lists of separate tokens, as that is how they will be retrieved from the API after the change
- https://github.com/duality-labs/duality/pull/285
    - previously, endpoint `/NicholasDotSol/duality/dex/tick/{pairId}` was: 
        - a single tick list ordered by increasing tick index;
    - afterwards, endpoint `/NicholasDotSol/duality/dex/tick_liquidity/{pairId}/{tokenIn}` is: 
        - two tick lists, one for each token side
            - token0 list ordered by decreasing tick index
            - token1 list ordered by increasing tick index
        - This new separation helps us query the most relevant ticks (those closest to the current price) in the first pages of pagination when there are many ticks within a tick pair
        
Although this PR does not upgrade to the new API, these changes should ensure less logic is required when switching to the new API version. The storage change itself has unlocked a little bit of optimization: allowing quicker and simpler calculation of middle / current price within a pair.