### PR TITLE
ci: fix semantic release CI build process 

### DIFF
--- a/.github/workflows/deploy_semantic_release.yml
+++ b/.github/workflows/deploy_semantic_release.yml
@@ -19,7 +19,7 @@ jobs:
           token: ${{ secrets.GH_TOKEN }}
 
       - name: Semantic Release
-        uses: cycjimmy/semantic-release-action@v3.0.0
+        uses: cycjimmy/semantic-release-action@v3.4.2
         id: semantic
         with:
           semantic_version: 19


### PR DESCRIPTION
update semantic release version to version with fix:
    - fix is detailed in https://github.com/cycjimmy/semantic-release-action/pull/162
      for release 3.4.2: https://github.com/cycjimmy/semantic-release-action/releases/tag/v3.4.2