### PR TITLE
ci: fix deploy previews are being created after PRs are merged

### DIFF
--- a/.github/workflows/deploy_preview.yml
+++ b/.github/workflows/deploy_preview.yml
@@ -14,9 +14,6 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - name: What was the trigger?
-        run: echo "${{ toJson(github) }}"
-
       - name: Checkout branch head (not merged head)
         uses: actions/checkout@v3
         with:


### PR DESCRIPTION
Deploy preview builds were being triggered after being merged when Semantic Release would add a "released" tag to the PR (and this labeling would meet the criteria to build a deploy preview)

Fixed to change the trigger to being *only*
- opened PR with label: 'deploy preview'
- pushed HEAD to PR with label: 'deploy preview' (synchronise: https://github.com/orgs/community/discussions/24567)
- the label 'deploy preview' has just been added (i.e. the event causing the workflow was a 'deploy preview' label)

The new condition appears to work:
- after adding the "deploy preview" label and then pushing a new commit
    - run https://github.com/duality-labs/duality-web-app/actions/runs/4624434948 was triggered
- then after adding the "CI" label
    - run https://github.com/duality-labs/duality-web-app/actions/runs/4624440023 was skipped
- then with a new commit pushed
    - run https://github.com/duality-labs/duality-web-app/actions/runs/4624466426 was triggered again 
    (and succeeds in building)