### PR TITLE
fix: Liquidity chart y-axis token value calculations were swapped

### DIFF
--- a/src/components/LiquiditySelector/LiquiditySelector.tsx
+++ b/src/components/LiquiditySelector/LiquiditySelector.tsx
@@ -564,10 +564,10 @@ export default function LiquiditySelector({
       fillBuckets(emptyBuckets[1], feeTicks[1], 'lower', getReserveBValue)
     );
     function getReserveAValue(reserve: BigNumber): BigNumber {
-      return reserve;
+      return reserve.multipliedBy(edgePrice);
     }
     function getReserveBValue(reserve: BigNumber): BigNumber {
-      return reserve.multipliedBy(edgePrice);
+      return reserve;
     }
   }, [emptyBuckets, feeTicks, edgePriceIndex]);
 
@@ -591,10 +591,10 @@ export default function LiquiditySelector({
       0
     );
     function getReserveAValue(reserve: BigNumber): BigNumber {
-      return reserve;
+      return reserve.multipliedBy(edgePrice);
     }
     function getReserveBValue(reserve: BigNumber): BigNumber {
-      return reserve.multipliedBy(edgePrice);
+      return reserve;
     }
   }, [emptyBuckets, tokenATicks, tokenBTicks, edgePriceIndex]);
 
@@ -1489,14 +1489,14 @@ function TicksGroup({
   // collect reserve height to calculate stats to use
   const tickValues = userTicks.flatMap((tick) =>
     [
-      tick?.reserveA.toNumber(),
-      tick?.reserveB.multipliedBy(currentPrice).toNumber(),
+      tick?.reserveA.multipliedBy(currentPrice).toNumber(),
+      tick?.reserveB.toNumber(),
     ].filter((reserve): reserve is number => Boolean(reserve))
   );
   const backgroundTickValues = backgroundTicks.flatMap((tick) =>
     [
-      tick?.reserveA.toNumber(),
-      tick?.reserveB.multipliedBy(currentPrice).toNumber(),
+      tick?.reserveA.multipliedBy(currentPrice).toNumber(),
+      tick?.reserveB.toNumber(),
     ].filter((reserve): reserve is number => Boolean(reserve))
   );
 
@@ -1663,23 +1663,23 @@ function TicksGroup({
         (reserveA.isGreaterThan(0)
           ? cumulativeTokenValues &&
             reserveA
+              .multipliedBy(currentPrice)
               .multipliedBy(scalingFactor)
               .dividedBy(cumulativeTokenValues)
           : cumulativeTokenValues &&
             reserveB
               .multipliedBy(scalingFactor)
-              .multipliedBy(currentPrice)
               .dividedBy(cumulativeTokenValues)) || new BigNumber(0);
       const backgroundValue =
         (background.reserveA.isGreaterThan(0)
           ? cumulativeTokenValues &&
             background.reserveA
+              .multipliedBy(currentPrice)
               .multipliedBy(scalingFactor)
               .dividedBy(cumulativeTokenValues)
           : cumulativeTokenValues &&
             background.reserveB
               .multipliedBy(scalingFactor)
-              .multipliedBy(currentPrice)
               .dividedBy(cumulativeTokenValues)) || new BigNumber(0);
 
       const minValue = totalValue.isLessThan(backgroundValue)


### PR DESCRIPTION
In the previous PR
- #376

There were errors made around the calculation of value heights from the different token reserves and prices. 

This corrects these errors, so that tokens with greater value are taller than the same amount of reserves of a lesser value token.

Previously (10 OSMO appears greater in value than 10 STRD):
![localhost_3000_pools_STRD_OSMO_add(FullHD) (1)](https://github.com/duality-labs/duality-web-app/assets/6194521/192b2de2-4904-4121-a86a-2ca8e1c8baf1)


Now (10 STRD appears greater in value than 10 OSMO):
![localhost_3000_pools_STRD_OSMO_add(FullHD) (2)](https://github.com/duality-labs/duality-web-app/assets/6194521/4298ad46-d80d-4052-ba8c-fbc268dcfe9b)
