### PR TITLE
fix: update chain IDs to new devnet

### DIFF
--- a/.env.deploy-previews
+++ b/.env.deploy-previews
@@ -8,4 +8,4 @@ REACT_APP__IS_MAINNET=testnet
 
 # Override chain name
 REACT_APP__CHAIN_ID=duality-devnet
-REACT_APP__CHAIN_NAME=Duality testnet
+REACT_APP__CHAIN_NAME=Duality Devnet

--- a/.env.development
+++ b/.env.development
@@ -7,5 +7,5 @@ REACT_APP__IS_MAINNET=testnet
 REACT_APP__DEV_TOKEN_DENOMS=["sdk.coin:token", "sdk.coin:stake"]
 
 # Override chain name
-REACT_APP__CHAIN_ID=duality-testnet-1
-REACT_APP__CHAIN_NAME=Duality testnet
+REACT_APP__CHAIN_ID=duality-devnet
+REACT_APP__CHAIN_NAME=Duality Devnet


### PR DESCRIPTION
The devnet that we are using for current previews and https://app.dev.duality.xyz has been change to be called "devnet" with the chain ID of "duality-devnet"