### PR TITLE
fix: token amount width to minimum width

### DIFF
--- a/src/components/TokenInputGroup/TokenInputGroup.tsx
+++ b/src/components/TokenInputGroup/TokenInputGroup.tsx
@@ -18,7 +18,6 @@ import './TokenInputGroup.scss';
 const { REACT_APP__MAX_FRACTION_DIGITS = '' } = process.env;
 const maxFractionDigits = parseInt(REACT_APP__MAX_FRACTION_DIGITS) || 20;
 
-const maxSignificantDigits = 20;
 const placeholder = '0';
 
 interface InputGroupProps {
@@ -147,14 +146,11 @@ export default function TokenInputGroup({
         disabled={disabledInput}
         style={useMemo(() => {
           return {
-            // set width of input based on current values but restrained to max characters
+            // set width as minimum amount available
             minWidth: '100%',
-            maxWidth: `${
-              maxSignificantDigits + (value?.includes('.') ? 1 : 0)
-            }ch`,
-            width: `${(value || placeholder).length}ch`,
+            width: 0,
           };
-        }, [value])}
+        }, [])}
       />
       <span className="token-group-value">{secondaryValue}</span>
     </div>


### PR DESCRIPTION
This PR changes the visual of the token input amounts, from a dynamic size to filling just the space available.

Before:
![localhost_3000_pools_USDC_ETH_add(FullHD) (2)](https://github.com/duality-labs/duality-web-app/assets/6194521/9df38121-7188-4fcc-ae8b-9e293e97b369)

after:
![localhost_3000_pools_USDC_ETH_add(FullHD) (1)](https://github.com/duality-labs/duality-web-app/assets/6194521/aff17164-9c02-4a5e-8c47-455341d9e598)
