### PR TITLE
feat: preserve intended liquidity shape on chart in add position page

### DIFF
--- a/src/pages/Pool/PoolManagement.tsx
+++ b/src/pages/Pool/PoolManagement.tsx
@@ -616,7 +616,7 @@ export default function PoolManagement({
       // calculate the used tick indexes
       const tickIndexValues = shapeUnitValueArray.map(
         (value, index, ticks): [tickIndex: number, value: number] => {
-          const xPercent = index / (ticks.length - 1);
+          const xPercent = index / Math.max(1, ticks.length - 1);
           // interpolate the whole tick index nearest to the array index
           const tickIndex = Math.round(
             rangeMinIndex + xPercent * (rangeMaxIndex - rangeMinIndex)


### PR DESCRIPTION
This PR changes the behavior of choosing tick deposit reserves on the liquidity chart:

Previously:
- editing the token input amounts and range bounds
    - would change the shape of the liquidity to deposit
    - it is easy to determine the total value deposited to a round number
![Screen Recording 2023-07-18 at 5 02 24 pm 2023-07-18 17_08_11](https://github.com/duality-labs/duality-web-app/assets/6194521/f8be277e-7d1c-498c-b36e-3466e25c3f0b)

Now:
- editing the shape and bounds of the liquidity curve
    - will change the amount of token not-last-edited
    - in this way you can set one side of the liquidty and modify the shape to match the desired liquidity position
    - it is easy to create the desired shape
    - it is not easy to create a deposit with both round numbers
![Screen Recording 2023-07-18 at 4 58 57 pm 2023-07-18 17_06_09](https://github.com/duality-labs/duality-web-app/assets/6194521/1df3fd66-cd85-4b09-8b00-3c810b501559)
