### PR TITLE
fix: semantic version release process

### DIFF
--- a/.github/workflows/deploy_semantic_release.yml
+++ b/.github/workflows/deploy_semantic_release.yml
@@ -52,7 +52,7 @@ jobs:
             @semantic-release/github
             @semantic-release/npm
             @semantic-release/exec
-            conventional-changelog-conventionalcommits
+            conventional-changelog-conventionalcommits@6
         env:
           GITHUB_TOKEN: ${{ secrets.GH_TOKEN }}
 

--- a/.github/workflows/deploy_semantic_release.yml
+++ b/.github/workflows/deploy_semantic_release.yml
@@ -18,18 +18,10 @@ jobs:
           fetch-depth: 0
           token: ${{ secrets.GH_TOKEN }}
 
-      # this step is a temporary fix due to issue in semantic release package
-      # see https://github.com/cycjimmy/semantic-release-action/issues/159#issuecomment-1490892625
-      - name: Use Node.js 14
-        uses: actions/setup-node@v3
-        with:
-          node-version: 14
-
       - name: Semantic Release
-        uses: cycjimmy/semantic-release-action@v3.4.2
+        uses: cycjimmy/semantic-release-action@v4
         id: semantic
         with:
-          semantic_version: 19
           # replace master branch with main as a release branch
           # see https://github.com/semantic-release/semantic-release/issues/1581
           # note that branches may already be filtered by the triggers of this workflow

--- a/.github/workflows/deploy_semantic_release.yml
+++ b/.github/workflows/deploy_semantic_release.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - main
+      - fix-semantic-release
 
 jobs:
   semantic_release:
@@ -22,6 +23,8 @@ jobs:
         uses: cycjimmy/semantic-release-action@v4
         id: semantic
         with:
+          dry_run: true
+          branch: fix-semantic-release
           # replace master branch with main as a release branch
           # see https://github.com/semantic-release/semantic-release/issues/1581
           # note that branches may already be filtered by the triggers of this workflow
@@ -29,6 +32,7 @@ jobs:
             [
               '+([0-9])?(.{+([0-9]),x}).x',
               'main',
+              'fix-semantic-release',
               'next',
               'next-major',
               {

--- a/.github/workflows/deploy_semantic_release.yml
+++ b/.github/workflows/deploy_semantic_release.yml
@@ -4,7 +4,6 @@ on:
   push:
     branches:
       - main
-      - fix-semantic-release
 
 jobs:
   semantic_release:
@@ -23,8 +22,6 @@ jobs:
         uses: cycjimmy/semantic-release-action@v4
         id: semantic
         with:
-          dry_run: true
-          branch: fix-semantic-release
           # replace master branch with main as a release branch
           # see https://github.com/semantic-release/semantic-release/issues/1581
           # note that branches may already be filtered by the triggers of this workflow
@@ -32,7 +29,6 @@ jobs:
             [
               '+([0-9])?(.{+([0-9]),x}).x',
               'main',
-              'fix-semantic-release',
               'next',
               'next-major',
               {

--- a/.github/workflows/deploy_semantic_release.yml
+++ b/.github/workflows/deploy_semantic_release.yml
@@ -45,13 +45,13 @@ jobs:
               }
             ]
           extra_plugins: |
-            @semantic-release/commit-analyzer
-            @semantic-release/release-notes-generator
-            @semantic-release/git
-            @semantic-release/changelog
-            @semantic-release/github
-            @semantic-release/npm
-            @semantic-release/exec
+            @semantic-release/commit-analyzer@^11.0.0
+            @semantic-release/release-notes-generator@^12.0.0
+            @semantic-release/git@^10.0.1
+            @semantic-release/changelog@^6.0.3
+            @semantic-release/github@^9.0.6
+            @semantic-release/npm@^11.0.0
+            @semantic-release/exec@^6.0.3
             conventional-changelog-conventionalcommits@6
         env:
           GITHUB_TOKEN: ${{ secrets.GH_TOKEN }}

--- a/release.config.js
+++ b/release.config.js
@@ -1,5 +1,21 @@
 /* eslint-disable no-template-curly-in-string */
 
+const conventionalCommitPresetConfig = {
+  types: [
+    { type: 'feat', section: 'Features' },
+    { type: 'fix', section: 'Fixes' },
+    { type: 'chore', hidden: false, section: 'Other' },
+    { type: 'docs', hidden: false, section: 'Other' },
+    { type: 'style', hidden: false, section: 'Other' },
+    { type: 'refactor', hidden: false, section: 'Other' },
+    { type: 'perf', hidden: false, section: 'Other' },
+    { type: 'revert', hidden: false, section: 'Other ' },
+    { type: 'test', hidden: false, section: 'Other ' },
+    { type: 'build', hidden: false, section: 'Other' },
+    { type: 'ci', hidden: true },
+  ],
+};
+
 /**
  * config for Semantic Release workflow
  * docs: https://github.com/semantic-release/semantic-release/blob/master/docs/usage/configuration.md#configuration
@@ -22,6 +38,7 @@ module.exports = {
           { type: 'fix', release: 'patch' },
           { type: 'perf', release: 'patch' },
         ],
+        presetConfig: conventionalCommitPresetConfig,
       },
     ],
     // create CHANGELOG text for changelog and commit description
@@ -29,21 +46,7 @@ module.exports = {
       '@semantic-release/release-notes-generator',
       {
         preset: 'conventionalcommits',
-        presetConfig: {
-          types: [
-            { type: 'feat', section: 'Features' },
-            { type: 'fix', section: 'Fixes' },
-            { type: 'chore', hidden: false, section: 'Other' },
-            { type: 'docs', hidden: false, section: 'Other' },
-            { type: 'style', hidden: false, section: 'Other' },
-            { type: 'refactor', hidden: false, section: 'Other' },
-            { type: 'perf', hidden: false, section: 'Other' },
-            { type: 'revert', hidden: false, section: 'Other ' },
-            { type: 'test', hidden: false, section: 'Other ' },
-            { type: 'build', hidden: false, section: 'Other' },
-            { type: 'ci', hidden: true },
-          ],
-        },
+        presetConfig: conventionalCommitPresetConfig,
       },
     ],
     // edits CHANGELOG.md

--- a/release.config.js
+++ b/release.config.js
@@ -1,21 +1,5 @@
 /* eslint-disable no-template-curly-in-string */
 
-const conventionalCommitPresetConfig = {
-  types: [
-    { type: 'feat', section: 'Features' },
-    { type: 'fix', section: 'Fixes' },
-    { type: 'chore', hidden: false, section: 'Other' },
-    { type: 'docs', hidden: false, section: 'Other' },
-    { type: 'style', hidden: false, section: 'Other' },
-    { type: 'refactor', hidden: false, section: 'Other' },
-    { type: 'perf', hidden: false, section: 'Other' },
-    { type: 'revert', hidden: false, section: 'Other ' },
-    { type: 'test', hidden: false, section: 'Other ' },
-    { type: 'build', hidden: false, section: 'Other' },
-    { type: 'ci', hidden: true },
-  ],
-};
-
 /**
  * config for Semantic Release workflow
  * docs: https://github.com/semantic-release/semantic-release/blob/master/docs/usage/configuration.md#configuration
@@ -38,7 +22,6 @@ module.exports = {
           { type: 'fix', release: 'patch' },
           { type: 'perf', release: 'patch' },
         ],
-        presetConfig: conventionalCommitPresetConfig,
       },
     ],
     // create CHANGELOG text for changelog and commit description
@@ -46,7 +29,21 @@ module.exports = {
       '@semantic-release/release-notes-generator',
       {
         preset: 'conventionalcommits',
-        presetConfig: conventionalCommitPresetConfig,
+        presetConfig: {
+          types: [
+            { type: 'feat', section: 'Features' },
+            { type: 'fix', section: 'Fixes' },
+            { type: 'chore', hidden: false, section: 'Other' },
+            { type: 'docs', hidden: false, section: 'Other' },
+            { type: 'style', hidden: false, section: 'Other' },
+            { type: 'refactor', hidden: false, section: 'Other' },
+            { type: 'perf', hidden: false, section: 'Other' },
+            { type: 'revert', hidden: false, section: 'Other ' },
+            { type: 'test', hidden: false, section: 'Other ' },
+            { type: 'build', hidden: false, section: 'Other' },
+            { type: 'ci', hidden: true },
+          ],
+        },
       },
     ],
     // edits CHANGELOG.md

--- a/release.config.js
+++ b/release.config.js
@@ -6,8 +6,8 @@
  **/
 
 module.exports = {
-  branches: ['main', 'fix-semantic-release'],
-  dryRun: true,
+  branches: ['main'],
+  dryRun: false,
   plugins: [
     // determine what type of semver change this commit may generate
     [

--- a/release.config.js
+++ b/release.config.js
@@ -6,8 +6,8 @@
  **/
 
 module.exports = {
-  branches: ['main'],
-  dryRun: false,
+  branches: ['main', 'fix-semantic-release'],
+  dryRun: true,
   plugins: [
     // determine what type of semver change this commit may generate
     [


### PR DESCRIPTION
This PR fixes the semantic version release process by

- upgrading cycjimmy/semantic-release-action
- downgrading conventional-changelog-conventionalcommits

It should be noted that downgrading conventionalcommits should not be necessary in the new fix available on @semantic-release@v22.0.0 as noted in https://github.com/semantic-release/semantic-release/issues/2932#issuecomment-1724864726.

However, it is not possible at the moment to add version 22 to the semantic-release-action config yet, eg:
```
      uses: cycjimmy/semantic-release-action@v4
      with:
          semantic_version: 22
```
Here the semantic-release-action will use semantic_version 21