### PR TITLE
feat: abstract consistent transaction notification toasts

### DIFF
--- a/src/components/Notifications/common.tsx
+++ b/src/components/Notifications/common.tsx
@@ -109,6 +109,7 @@ export function checkMsgErrorToast(
 ) {
   const { transactionHash } = err?.response || {};
   const transactionLink = `${REACT_APP__REST_API}/cosmos/tx/v1beta1/txs/${transactionHash}`;
+  // pass error to console for developers
   // eslint-disable-next-line no-console
   console.error(
     err,
@@ -133,6 +134,7 @@ export function createErrorToast(
   if (err instanceof TransactionToastError) {
     return;
   }
+  // pass error to console for developers
   // eslint-disable-next-line no-console
   console.error(err);
   return toast.error(title || 'Error', {

--- a/src/components/Notifications/common.tsx
+++ b/src/components/Notifications/common.tsx
@@ -7,6 +7,7 @@ import {
 import { toast } from './Notifications';
 import { DeliverTxResponse } from '@cosmjs/stargate';
 import { coerceError } from '../../lib/utils/error';
+import { seconds } from '../../lib/utils/time';
 
 const { REACT_APP__REST_API } = process.env;
 
@@ -56,7 +57,7 @@ export function checkMsgSuccessToast(
         descriptionLink ||
         `${REACT_APP__REST_API}/cosmos/tx/v1beta1/txs/${transactionHash}`,
       icon: <FontAwesomeIcon icon={faCheckCircle} />,
-      duration: 15e3,
+      duration: 15 * seconds,
       dismissable: true,
     });
   }
@@ -72,7 +73,7 @@ export function checkMsgRejectedToast(
       description: description || 'You declined the transaction',
       descriptionLink,
       icon: <FontAwesomeIcon icon={faCircleXmark} />,
-      duration: 5e3,
+      duration: 5 * seconds,
       dismissable: true,
     });
   }

--- a/src/components/Notifications/common.tsx
+++ b/src/components/Notifications/common.tsx
@@ -133,7 +133,6 @@ export async function createTransactionToasts<T extends MinimalTxResponse>(
     onSuccessMessage,
     onError,
     onErrorMessage,
-    rethrowError = false,
   }: {
     id?: string;
     onLoadingMessage?: string;
@@ -141,7 +140,6 @@ export async function createTransactionToasts<T extends MinimalTxResponse>(
     onSuccessMessage?: string;
     onError?: (error: Error, res?: T) => ToastOptions | undefined | void;
     onErrorMessage?: string;
-    rethrowError?: boolean;
   } = {}
 ): Promise<T | undefined> {
   // start toasts
@@ -180,11 +178,7 @@ export async function createTransactionToasts<T extends MinimalTxResponse>(
       checkMsgRejectedToast(err, toastOptions) ||
         checkMsgOutOfGasToast(err, toastOptions) ||
         checkMsgErrorToast(err, toastOptions);
-
-      // only throw the error if it will be handled
-      if (rethrowError) {
-        throw err;
-      }
+      // return undefined as a nicer type than void
       return undefined;
     });
 }

--- a/src/components/Notifications/common.tsx
+++ b/src/components/Notifications/common.tsx
@@ -125,6 +125,22 @@ export function checkMsgErrorToast(
   });
 }
 
+export function createErrorToast(
+  err: Error,
+  { id, title, description, descriptionLink }: ToastOptions = {}
+) {
+  // eslint-disable-next-line no-console
+  console.error(err);
+  return toast.error(title || 'Error', {
+    id,
+    description: description || 'Unknown error',
+    descriptionLink: descriptionLink,
+    icon: <FontAwesomeIcon icon={faCircleXmark} />,
+    duration: 7 * seconds,
+    dismissable: true,
+  });
+}
+
 export class TransactionToastError extends Error {}
 
 export async function createTransactionToasts<T extends MinimalTxResponse>(

--- a/src/components/Notifications/common.tsx
+++ b/src/components/Notifications/common.tsx
@@ -129,6 +129,10 @@ export function createErrorToast(
   err: Error,
   { id, title, description, descriptionLink }: ToastOptions = {}
 ) {
+  // skip if this error has already been used to show a transaction toast
+  if (err instanceof TransactionToastError) {
+    return;
+  }
   // eslint-disable-next-line no-console
   console.error(err);
   return toast.error(title || 'Error', {

--- a/src/components/Notifications/common.tsx
+++ b/src/components/Notifications/common.tsx
@@ -126,9 +126,7 @@ export function checkMsgErrorToast(
 
 export class TransactionToastError extends Error {}
 
-export async function createTransactionToasts<
-  T extends MinimalTxResponse
->(
+export async function createTransactionToasts<T extends MinimalTxResponse>(
   callback: (id: string) => Promise<T>,
   {
     // create default ID if it does not exist yet

--- a/src/components/Notifications/common.tsx
+++ b/src/components/Notifications/common.tsx
@@ -123,9 +123,7 @@ export function checkMsgErrorToast(
   });
 }
 
-export async function handleStandardToastTransaction<
-  T extends MinimalTxResponse
->(
+export async function createTransactionToasts<T extends MinimalTxResponse>(
   callback: (id: string) => Promise<T>,
   {
     // create default ID if it does not exist yet

--- a/src/lib/utils/error.ts
+++ b/src/lib/utils/error.ts
@@ -1,0 +1,60 @@
+// determine if an unknown type is an Error (common for a catch block)
+const isError = (err: unknown): err is Error => {
+  return (
+    // return error from this frame
+    err instanceof Error ||
+    // or error from another frame
+    // see: https://stackoverflow.com/questions/30469261/checking-for-typeof-error-in-js#61958148
+    Object.prototype.toString.call(err) === '[object Error]'
+  );
+};
+
+// ensure that an unknown error can be handled as an error
+export function coerceError(
+  err: unknown,
+  // you can pass a default error message or a message creator function
+  // if the error message needs to be disambiguated
+  messageOrCreateMessage:
+    | string
+    | ((err: unknown) => string) = createDefaultErrorMessage
+): Error {
+  // hopefully it is already an error
+  if (isError(err)) {
+    return err;
+  }
+  // if some dependency somewhere has thrown a non-error, attempt to handle it
+  else {
+    const errorMessage =
+      typeof messageOrCreateMessage === 'function'
+        ? // use custom error message creation
+          messageOrCreateMessage(err)
+        : // attempt to default parsing out error string for most types
+          messageOrCreateMessage;
+    return new Error(errorMessage);
+  }
+}
+
+// default error message parsing attempts to convert known types to a string
+function createDefaultErrorMessage(err: unknown): string {
+  const objectType = Object.prototype.toString.call(err);
+  switch (objectType) {
+    case '[object Undefined]':
+      return 'Unknown Error';
+    case '[object Boolean]':
+    case '[object Number]':
+    case '[object String]':
+      return `${err}`;
+    case '[object Object]':
+    case '[object Array]': {
+      // lookup possible message attribute on an object or array
+      // (yes it is possible to add a string key attribute to an array)
+      const message = (err as { message?: string }).message;
+      if (typeof message === 'string') {
+        return message;
+      }
+      return JSON.stringify(err);
+    }
+    default:
+      return `Unexpected ${objectType} Error`;
+  }
+}

--- a/src/pages/Bridge/useBridge.ts
+++ b/src/pages/Bridge/useBridge.ts
@@ -20,7 +20,6 @@ import {
 } from '../../lib/web3/wallets/keplr';
 
 import {
-  TransactionToastError,
   createErrorToast,
   createTransactionToasts,
 } from '../../components/Notifications/common';
@@ -186,10 +185,8 @@ export default function useBridge(
         setValidating(false);
       } catch (maybeError: unknown) {
         const err = coerceError(maybeError);
-        // handle unhandled errors
-        if (!(err instanceof TransactionToastError)) {
-          createErrorToast(err);
-        }
+        // handle unhandled errors (handled errors won't be processed twice)
+        createErrorToast(err);
         // set error state
         setValidating(false);
         setData(undefined);

--- a/src/pages/Bridge/useBridge.ts
+++ b/src/pages/Bridge/useBridge.ts
@@ -190,16 +190,12 @@ export default function useBridge(
         if (!(err instanceof TransactionToastError)) {
           createErrorToast(err);
         }
-        // add error to state
-        onError(err);
-        // pass error through
-        throw err;
-      }
-
-      function onError(err: Error) {
+        // set error state
         setValidating(false);
         setData(undefined);
         setError(err.message);
+        // pass error through
+        throw err;
       }
     },
     [

--- a/src/pages/Bridge/useBridge.ts
+++ b/src/pages/Bridge/useBridge.ts
@@ -21,10 +21,9 @@ import {
 
 import {
   TransactionToastError,
+  createErrorToast,
   createTransactionToasts,
 } from '../../components/Notifications/common';
-import { toast } from '../../components/Notifications';
-import { seconds } from '../../lib/utils/time';
 import { coerceError } from '../../lib/utils/error';
 
 async function bridgeToken(
@@ -194,15 +193,8 @@ export default function useBridge(
         }
         // add error to state
         onError(err);
-        // pass error to console for developer
-        // eslint-disable-next-line no-console
-        console.error(err);
-        // add transient error message to user
-        toast.error('Transaction Failed', {
-          description: err.message,
-          duration: 7 * seconds,
-          dismissable: true,
-        });
+        // handle unhandled errors
+        createErrorToast(err);
         // pass error through
         throw err;
       }

--- a/src/pages/Bridge/useBridge.ts
+++ b/src/pages/Bridge/useBridge.ts
@@ -180,17 +180,18 @@ export default function useBridge(
         // make the bridge transaction to the from chain (with correct signing)
         const client = await ibcClient(offlineSigner, rpcClientEndpointFrom);
         await bridgeToken(request, client, account.address);
-
         // exit loading state
         setValidating(false);
       } catch (maybeError: unknown) {
         const err = coerceError(maybeError);
         // handle unhandled errors (handled errors won't be processed twice)
         createErrorToast(err);
+
         // set error state
         setValidating(false);
         setData(undefined);
         setError(err.message);
+
         // pass error through
         throw err;
       }

--- a/src/pages/Bridge/useBridge.ts
+++ b/src/pages/Bridge/useBridge.ts
@@ -59,13 +59,15 @@ async function bridgeToken(
   //       so passing different chains interchangably works fine
   // future: update when there is a transition to a newer version
 
-  return client.signAndBroadcast(
-    signingAddress,
-    [ibc.applications.transfer.v1.MessageComposer.withTypeUrl.transfer(msg)],
-    {
-      gas: '100000',
-      amount: [],
-    }
+  return createTransactionToasts(() =>
+    client.signAndBroadcast(
+      signingAddress,
+      [ibc.applications.transfer.v1.MessageComposer.withTypeUrl.transfer(msg)],
+      {
+        gas: '100000',
+        amount: [],
+      }
+    )
   );
 }
 
@@ -177,9 +179,7 @@ export default function useBridge(
         // process intended request
         // make the bridge transaction to the from chain (with correct signing)
         const client = await ibcClient(offlineSigner, rpcClientEndpointFrom);
-        await createTransactionToasts(() =>
-          bridgeToken(request, client, account.address)
-        );
+        await bridgeToken(request, client, account.address);
 
         // exit loading state
         setValidating(false);

--- a/src/pages/Bridge/useBridge.ts
+++ b/src/pages/Bridge/useBridge.ts
@@ -178,23 +178,20 @@ export default function useBridge(
         // process intended request
         // make the bridge transaction to the from chain (with correct signing)
         const client = await ibcClient(offlineSigner, rpcClientEndpointFrom);
-        await createTransactionToasts(
-          () => bridgeToken(request, client, account.address),
-          { onError }
+        await createTransactionToasts(() =>
+          bridgeToken(request, client, account.address)
         );
 
         // exit loading state
         setValidating(false);
       } catch (maybeError: unknown) {
         const err = coerceError(maybeError);
-        // pass through already handled toast error
-        if (err instanceof TransactionToastError) {
-          throw err;
+        // handle unhandled errors
+        if (!(err instanceof TransactionToastError)) {
+          createErrorToast(err);
         }
         // add error to state
         onError(err);
-        // handle unhandled errors
-        createErrorToast(err);
         // pass error through
         throw err;
       }

--- a/src/pages/Bridge/useBridge.ts
+++ b/src/pages/Bridge/useBridge.ts
@@ -1,7 +1,7 @@
 import { useCallback, useState } from 'react';
 import BigNumber from 'bignumber.js';
 import { ibc } from '@duality-labs/dualityjs';
-import { DeliverTxResponse, SigningStargateClient } from '@cosmjs/stargate';
+import { SigningStargateClient } from '@cosmjs/stargate';
 import { Chain } from '@chain-registry/types';
 import {
   MsgTransfer,
@@ -20,14 +20,12 @@ import {
 } from '../../lib/web3/wallets/keplr';
 
 import {
-  checkMsgErrorToast,
-  checkMsgOutOfGasToast,
-  checkMsgRejectedToast,
-  checkMsgSuccessToast,
-  createLoadingToast,
+  TransactionToastError,
+  createTransactionToasts,
 } from '../../components/Notifications/common';
 import { toast } from '../../components/Notifications';
 import { seconds } from '../../lib/utils/time';
+import { coerceError } from '../../lib/utils/error';
 
 async function bridgeToken(
   msg: MsgTransfer,
@@ -63,43 +61,14 @@ async function bridgeToken(
   //       so passing different chains interchangably works fine
   // future: update when there is a transition to a newer version
 
-  // send message to chain
-  const id = `${Date.now()}.${Math.random}`;
-
-  createLoadingToast({ id, description: 'Executing your trade' });
-
-  return client
-    .signAndBroadcast(
-      signingAddress,
-      [ibc.applications.transfer.v1.MessageComposer.withTypeUrl.transfer(msg)],
-      {
-        gas: '100000',
-        amount: [],
-      }
-    )
-    .then(function (res): void {
-      if (!res) {
-        throw new Error('No response');
-      }
-      const { code } = res;
-      if (!checkMsgSuccessToast(res, { id })) {
-        const error: Error & { response?: DeliverTxResponse } = new Error(
-          `Tx error: ${code}`
-        );
-        error.response = res;
-        throw error;
-      }
-    })
-    .catch(function (err: Error & { response?: DeliverTxResponse }) {
-      // catch transaction errors
-      // chain toast checks so only one toast may be shown
-      checkMsgRejectedToast(err, { id }) ||
-        checkMsgOutOfGasToast(err, { id }) ||
-        checkMsgErrorToast(err, { id });
-
-      // don't rethrow error, we should error message toasts for previous errors
-      // throw err;
-    });
+  return client.signAndBroadcast(
+    signingAddress,
+    [ibc.applications.transfer.v1.MessageComposer.withTypeUrl.transfer(msg)],
+    {
+      gas: '100000',
+      amount: [],
+    }
+  );
 }
 
 export default function useBridge(
@@ -127,16 +96,23 @@ export default function useBridge(
 
   const sendRequest = useCallback(
     async (request: MsgTransfer) => {
-      // check things around the request (not the request payload)
-      if (!request) return onError('Missing Token and Amount');
-      if (!chainFrom) return onError('No Source Chain connected');
-      if (!chainTo) return onError('No Destination Chain connected');
-
-      setValidating(true);
-      setError(undefined);
-      setData(undefined);
-
       try {
+        // check synchronous things around the request (not the request payload)
+        if (!request) {
+          throw new Error('Missing Token and Amount');
+        }
+        if (!chainFrom) {
+          throw new Error('No Source Chain connected');
+        }
+        if (!chainTo) {
+          throw new Error('No Destination Chain connected');
+        }
+
+        // set loading state
+        setValidating(true);
+        setError(undefined);
+        setData(undefined);
+
         // check async things around the request (not the request payload)
         const offlineSigner = await getKeplrWallet(chainFrom.chain_id);
         if (!offlineSigner) {
@@ -199,35 +175,42 @@ export default function useBridge(
         if (!rpcClientEndpointFrom) {
           throw new Error('No source chain transaction endpoint found');
         }
+
+        // process intended request
         // make the bridge transaction to the from chain (with correct signing)
         const client = await ibcClient(offlineSigner, rpcClientEndpointFrom);
-        await bridgeToken(request, client, account.address);
+        await createTransactionToasts(
+          () => bridgeToken(request, client, account.address),
+          { onError }
+        );
+
+        // exit loading state
         setValidating(false);
-      } catch (err: unknown) {
-        // add error to state
-        // add custom error message for known error codes
-        if ((err as { response?: { code?: number } })?.response?.code === 11) {
-          onError();
+      } catch (maybeError: unknown) {
+        const err = coerceError(maybeError);
+        // pass through already handled toast error
+        if (err instanceof TransactionToastError) {
           throw err;
         }
-        onError((err as Error)?.message ?? 'Unknown error');
+        // add error to state
+        onError(err);
         // pass error to console for developer
         // eslint-disable-next-line no-console
         console.error(err);
+        // add transient error message to user
+        toast.error('Transaction Failed', {
+          description: err.message,
+          duration: 7 * seconds,
+          dismissable: true,
+        });
         // pass error through
         throw err;
       }
 
-      function onError(message?: string) {
+      function onError(err: Error) {
         setValidating(false);
         setData(undefined);
-        setError(message);
-        // add transient error message to user
-        toast.error('Transaction Failed', {
-          description: message,
-          duration: 7 * seconds,
-          dismissable: true,
-        });
+        setError(err.message);
       }
     },
     [


### PR DESCRIPTION
This PR creates a way to handle notification toasts consistently during a chain transaction request. 

Errors may occur during:
- sync validation before request
- async validation before request
- in the request mechanism (eg. connection timeout)
- on the chain

All these errors should ideally be handled simply in a single catch block so that each transaction request hook doesn't need to implement a lot of logic itself. with the help of:
- `coerceError` to account for inconsistent error throwing by unknown dependencies and
- `createErrorToast` to selectively toast errors that have not been toasted already by the handler

The example in the `useBridge -> sendRequest -> try -> catch` block can now simply ask for a possible error toast and continue with its own state logic.