### PR TITLE
feat: improve IBC bridging toast notifications

### DIFF
--- a/src/lib/web3/utils/events.ts
+++ b/src/lib/web3/utils/events.ts
@@ -46,13 +46,15 @@ export type DexMessageAction =
   | 'Withdraw'
   | 'TickUpdate';
 
-export type ChainEvent = CosmosEvent | DexEvent;
+export type ChainEvent = CosmosEvent | IBCEvent | DexEvent;
 
 export type CosmosEvent =
   | TxFeeEvent
   | CoinTransferEvent
   | CoinSpentEvent
   | CoinReceivedEvent;
+
+export type IBCEvent = IBCSendPacketEvent | IBCReceivePacketEvent;
 
 export type DexEvent =
   | DexPlaceLimitOrderEvent
@@ -160,6 +162,31 @@ export interface TxFeeEvent {
     fee: CoinString;
     fee_payer: WalletAddress;
   };
+}
+
+interface IBCPacketEventAttributes {
+  packet_data: string; // JSON string representation of the packet
+  packet_data_hex: string;
+  packet_timeout_height: string;
+  packet_timeout_timestamp: string;
+  packet_sequence: string;
+  packet_src_port: string;
+  packet_src_channel: string;
+  packet_dst_port: string;
+  packet_dst_channel: string;
+  packet_channel_ordering: string;
+  packet_connection: string;
+  connection_id: string;
+}
+
+export interface IBCSendPacketEvent {
+  type: 'send_packet';
+  attributes: IBCPacketEventAttributes;
+}
+
+export interface IBCReceivePacketEvent {
+  type: 'recv_packet';
+  attributes: IBCPacketEventAttributes;
 }
 
 export function getSpentTokenAmount(

--- a/src/pages/Bridge/useBridge.ts
+++ b/src/pages/Bridge/useBridge.ts
@@ -26,9 +26,9 @@ import {
 import { coerceError } from '../../lib/utils/error';
 
 async function bridgeToken(
-  msg: MsgTransfer,
   client: SigningStargateClient,
-  signingAddress: string
+  signingAddress: string,
+  msg: MsgTransfer
 ) {
   const {
     sender,
@@ -179,7 +179,7 @@ export default function useBridge(
         // process intended request
         // make the bridge transaction to the from chain (with correct signing)
         const client = await ibcClient(offlineSigner, rpcClientEndpointFrom);
-        await bridgeToken(request, client, account.address);
+        await bridgeToken(client, account.address, request);
         // exit loading state
         setValidating(false);
       } catch (maybeError: unknown) {

--- a/src/pages/Bridge/useBridge.ts
+++ b/src/pages/Bridge/useBridge.ts
@@ -1,14 +1,20 @@
 import { useCallback, useState } from 'react';
 import BigNumber from 'bignumber.js';
 import { ibc } from '@duality-labs/dualityjs';
-import { SigningStargateClient } from '@cosmjs/stargate';
+import { DeliverTxResponse, SigningStargateClient } from '@cosmjs/stargate';
 import { Chain } from '@chain-registry/types';
 import {
   MsgTransfer,
   MsgTransferResponse,
 } from '@duality-labs/dualityjs/types/codegen/ibc/applications/transfer/v1/tx';
+import { GetTxsEventRequest } from '@duality-labs/dualityjs/types/codegen/cosmos/tx/v1beta1/service';
 
 import { ibcClient } from '../../lib/web3/rpcMsgClient';
+import {
+  IBCSendPacketEvent,
+  decodeEvent,
+  mapEventAttributes,
+} from '../../lib/web3/utils/events';
 import {
   useIbcOpenTransfers,
   useRemoteChainRestEndpoint,
@@ -24,6 +30,7 @@ import {
   createTransactionToasts,
 } from '../../components/Notifications/common';
 import { coerceError } from '../../lib/utils/error';
+import { seconds } from '../../lib/utils/time';
 
 async function bridgeToken(
   client: SigningStargateClient,
@@ -59,15 +66,13 @@ async function bridgeToken(
   //       so passing different chains interchangably works fine
   // future: update when there is a transition to a newer version
 
-  return createTransactionToasts(() =>
-    client.signAndBroadcast(
-      signingAddress,
-      [ibc.applications.transfer.v1.MessageComposer.withTypeUrl.transfer(msg)],
-      {
-        gas: '100000',
-        amount: [],
-      }
-    )
+  return await client.signAndBroadcast(
+    signingAddress,
+    [ibc.applications.transfer.v1.MessageComposer.withTypeUrl.transfer(msg)],
+    {
+      gas: '100000',
+      amount: [],
+    }
   );
 }
 
@@ -179,7 +184,76 @@ export default function useBridge(
         // process intended request
         // make the bridge transaction to the from chain (with correct signing)
         const client = await ibcClient(offlineSigner, rpcClientEndpointFrom);
-        await bridgeToken(client, account.address, request);
+        const responseFrom = await createTransactionToasts(
+          () => bridgeToken(client, account.address, request),
+          {
+            onLoadingMessage: 'Source Chain Transaction Started...',
+            onSuccessMessage: 'Source Chain Transaction Successful!',
+            onErrorMessage: 'Source Chain Transaction Failed',
+            restEndpoint: restEndpointFrom ?? undefined,
+          }
+        );
+        if (!responseFrom) {
+          throw new Error('Could not confirm source chain transaction');
+        }
+        // confirm the transaction is received on the receiving chain
+        const events = [
+          // collect events with mapped attributes
+          ...responseFrom.events.map(mapEventAttributes),
+          // collect events with potential mapped base64 attributes
+          // we do this because we haven't checked whether the source chain
+          // is pre-v0.35.0 Tendermint or not so the atrributes may be encoded
+          ...responseFrom.events.map(decodeEvent).map(mapEventAttributes),
+        ];
+        const packetDataHex =
+          events &&
+          events.find((event): event is IBCSendPacketEvent => {
+            return event.type === 'send_packet';
+          })?.attributes.packet_data_hex;
+        if (!packetDataHex) {
+          throw new Error('Could not confirm sending chain transaction data');
+        }
+
+        const responseTo = await createTransactionToasts(
+          async () => {
+            // poll for expected IBC packet, but timeout after a period of time
+            const timeout = Date.now() + 30 * seconds;
+            while (Date.now() <= timeout) {
+              const res = await lcdClientTo.cosmos.tx.v1beta1.getTxsEvent({
+                events: `recv_packet.packet_data_hex='${packetDataHex}'`,
+                limit: '1',
+                // note: hacking request payload type because it is very wrong
+              } as unknown as GetTxsEventRequest);
+              const txResult = res?.tx_responses?.at(0);
+              if (txResult) {
+                // translate response into format for toasts
+                return {
+                  code: txResult.code,
+                  transactionHash: txResult.txhash,
+                  rawLog: txResult.raw_log,
+                  gasUsed: txResult.gas_used.toNumber(),
+                  gasWanted: txResult.gas_wanted.toNumber(),
+                } as DeliverTxResponse;
+              }
+              // wait a little while
+              await new Promise((resolve) => setTimeout(resolve, 3 * seconds));
+            }
+            // while timeout reached
+            throw new Error(
+              'Timed out waiting for receiving chain confirmation'
+            );
+          },
+          {
+            onLoadingMessage: 'Destination Chain Transaction Started...',
+            onSuccessMessage: 'Destination Chain Transaction Successful!',
+            onErrorMessage: 'Destination Chain Transaction Failed',
+            restEndpoint: restEndpointTo ?? undefined,
+          }
+        );
+        if (!responseTo) {
+          throw new Error('Could not confirm destination chain transaction');
+        }
+
         // exit loading state
         setValidating(false);
       } catch (maybeError: unknown) {

--- a/src/pages/Bridge/useBridge.ts
+++ b/src/pages/Bridge/useBridge.ts
@@ -237,7 +237,11 @@ export default function useBridge(
                 ];
                 const receiveEvent = events.find(
                   (event): event is IBCReceivePacketEvent => {
-                    return event.type === 'recv_packet';
+                    // return the receive packet type that has the correctly decoded keys
+                    return (
+                      event.type === 'recv_packet' &&
+                      !!event.attributes.packet_data_hex
+                    );
                   }
                 );
                 // compare the timeout timestamp as it is the most unique identifier


### PR DESCRIPTION
This PR adds a waiting state for the IBC transfer process and 2 notification toasts instead of one (previously the notification state existed only for the source chain request)

The 2 notification toasts allow the state of the request for both the chains (source/destination) to be seen and independently linked to.

Preview: halfway through an IBC transfer, waiting for funds to appear on the destination chain.
![localhost_3000_bridge(FullHD) (30)](https://github.com/duality-labs/duality-web-app/assets/6194521/9cbd92a4-0595-4152-8dd8-c291d86191c6)
