### PR TITLE
refactor: avoid static token list lookups

### DIFF
--- a/src/lib/web3/hooks/useTokens.ts
+++ b/src/lib/web3/hooks/useTokens.ts
@@ -283,7 +283,9 @@ export function useTokensWithIbcInfo(tokenList: Token[]) {
 }
 
 const ibcDenomRegex = /^ibc\/[0-9A-Fa-f]+$/;
+// allow matching by token symbol or IBC denom string (typically from a URL)
 function matchTokenBySymbol(symbol: string | undefined) {
+  // match nothing
   if (!symbol) {
     return () => false;
   }

--- a/src/lib/web3/hooks/useTokens.ts
+++ b/src/lib/web3/hooks/useTokens.ts
@@ -236,6 +236,16 @@ export function useIbcTokens(sortFunction = defaultSort) {
   }, [sortFunction, ibcOpenTransfersInfo]);
 }
 
+export function useToken(
+  tokenAddress: string | undefined,
+  matchFunction = matchTokenByAddress
+): Token | undefined {
+  const tokens = useTokens();
+  return useMemo(() => {
+    return tokenAddress ? tokens.find(matchFunction(tokenAddress)) : undefined;
+  }, [matchFunction, tokenAddress, tokens]);
+}
+
 // connected IBC info into given token list
 export function useTokensWithIbcInfo(tokenList: Token[]) {
   const ibcOpenTransfersInfo = useIbcOpenTransfers();

--- a/src/lib/web3/hooks/useTokens.ts
+++ b/src/lib/web3/hooks/useTokens.ts
@@ -282,25 +282,33 @@ export function useTokensWithIbcInfo(tokenList: Token[]) {
   }, [tokenList, ibcOpenTransfersInfo]);
 }
 
-export function getTokenBySymbol(symbol: string | undefined) {
+const ibcDenomRegex = /^ibc\/[0-9A-Fa-f]+$/;
+function matchTokenBySymbol(symbol: string | undefined) {
+  if (!symbol) {
+    return () => false;
+  }
+  // match denom aliases for IBC tokens
+  if (symbol.match(ibcDenomRegex)) {
+    return (tokenWithIbcInfo: Token) => {
+      return tokenWithIbcInfo.denom_units?.find((unit) =>
+        unit.aliases?.find((alias) => alias === symbol)
+      );
+    };
+  }
+  // match regular symbols for local tokens
+  else {
+    return (token: Token) => {
+      return token.symbol === symbol;
+    };
+  }
+}
+export function useTokenBySymbol(symbol: string | undefined) {
+  const allTokens = useTokens();
+  const tokensWithIbcInfo = useTokensWithIbcInfo(allTokens);
   if (!symbol) {
     return undefined;
   }
-  if (isTestnet) {
-    tokenListCache['dualityTokens'] =
-      tokenListCache['dualityTokens'] || getTokens(dualityTokensFilter);
-    return tokenListCache['dualityTokens'].find(
-      (token) => token.symbol === symbol
-    );
-  } else {
-    // todo: in mainnet find the best way to differentiate between symbols
-    // maybe use addresses instead or as a fallback to be more specific?
-    tokenListCache['mainnetTokens'] =
-      tokenListCache['mainnetTokens'] || getTokens(mainnetTokens);
-    return tokenListCache['mainnetTokens'].find(
-      (token) => token.symbol === symbol
-    );
-  }
+  return tokensWithIbcInfo.find(matchTokenBySymbol(symbol));
 }
 
 function defaultSort(a: Token, b: Token) {

--- a/src/lib/web3/hooks/useTokens.ts
+++ b/src/lib/web3/hooks/useTokens.ts
@@ -290,7 +290,7 @@ function matchTokenBySymbol(symbol: string | undefined) {
   // match denom aliases for IBC tokens
   if (symbol.match(ibcDenomRegex)) {
     return (tokenWithIbcInfo: Token) => {
-      return tokenWithIbcInfo.denom_units?.find((unit) =>
+      return !!tokenWithIbcInfo.denom_units?.find((unit) =>
         unit.aliases?.find((alias) => alias === symbol)
       );
     };

--- a/src/lib/web3/hooks/useTokens.ts
+++ b/src/lib/web3/hooks/useTokens.ts
@@ -25,10 +25,6 @@ const {
 
 const isTestnet = REACT_APP__IS_MAINNET !== 'mainnet';
 
-interface AddressableToken extends Token {
-  address: string; // only accept routeable tokens in lists
-}
-
 type TokenList = Array<Token>;
 
 const dualityMainToken: Token = {
@@ -178,15 +174,6 @@ function getTokens(condition: (chain: Chain) => boolean) {
       .concat(testnetTokens || [])
   );
 }
-
-export const addressableTokenMap = getTokens(Boolean).reduce<{
-  [tickAddress: string]: AddressableToken;
-}>((result, asset) => {
-  if (asset.address) {
-    result[asset.address] = asset as AddressableToken;
-  }
-  return result;
-}, {});
 
 const tokenListCache: {
   [key: string]: TokenList;

--- a/src/pages/MyLiquidity/MyLiquidity.tsx
+++ b/src/pages/MyLiquidity/MyLiquidity.tsx
@@ -1,5 +1,5 @@
 import { Link, useMatch, useNavigate } from 'react-router-dom';
-import { useCallback, useMemo } from 'react';
+import { useCallback } from 'react';
 import {
   Actions,
   MyPoolsTableCard,
@@ -15,7 +15,7 @@ import useUserTokens from '../../lib/web3/hooks/useUserTokens';
 import { Token } from '../../lib/web3/utils/tokens';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { faArrowAltCircleRight } from '@fortawesome/free-solid-svg-icons';
-import { getTokenBySymbol } from '../../lib/web3/hooks/useTokens';
+import { useTokenBySymbol } from '../../lib/web3/hooks/useTokens';
 import MyPoolStakesTableCard from '../../components/cards/PoolStakesTableCard';
 
 export default function MyLiquidity() {
@@ -126,15 +126,8 @@ function Tables() {
   );
 
   const matchTokens = useMatch('/portfolio/pools/:tokenA/:tokenB');
-
-  const [tokenA, tokenB] = useMemo<[Token?, Token?]>(() => {
-    if (matchTokens) {
-      const tokenA = getTokenBySymbol(matchTokens.params['tokenA']);
-      const tokenB = getTokenBySymbol(matchTokens.params['tokenB']);
-      return [tokenA, tokenB];
-    }
-    return [];
-  }, [matchTokens]);
+  const tokenA = useTokenBySymbol(matchTokens?.params['tokenA']);
+  const tokenB = useTokenBySymbol(matchTokens?.params['tokenB']);
 
   const goToPositionManagementPage = useCallback(
     ([token0, token1]: [Token, Token]) => {

--- a/src/pages/Pool/Pools.tsx
+++ b/src/pages/Pool/Pools.tsx
@@ -1,10 +1,10 @@
-import { useState, useCallback, useMemo } from 'react';
+import { useState, useCallback } from 'react';
 import { Link, useMatch, useNavigate } from 'react-router-dom';
 import PoolsTableCard, {
   MyPoolsTableCard,
 } from '../../components/cards/PoolsTableCard';
 
-import { getTokenBySymbol } from '../../lib/web3/hooks/useTokens';
+import { useTokenBySymbol } from '../../lib/web3/hooks/useTokens';
 import { Token } from '../../lib/web3/utils/tokens';
 import { useUserPositionsShareValues } from '../../lib/web3/hooks/useUserShareValues';
 
@@ -33,14 +33,8 @@ function Pools() {
       matchTokenManagement.params['addOrEdit'] === 'edit');
   const match = matchTokens || matchTokenManagement;
 
-  const [tokenA, tokenB] = useMemo<[Token?, Token?]>(() => {
-    if (match) {
-      const tokenA = getTokenBySymbol(match.params['tokenA']);
-      const tokenB = getTokenBySymbol(match.params['tokenB']);
-      return [tokenA, tokenB];
-    }
-    return [];
-  }, [match]);
+  const tokenA = useTokenBySymbol(match?.params['tokenA']);
+  const tokenB = useTokenBySymbol(match?.params['tokenB']);
 
   // don't change tokens directly:
   // change the path name which will in turn update the tokens selected

--- a/src/pages/Swap/Swap.tsx
+++ b/src/pages/Swap/Swap.tsx
@@ -12,7 +12,7 @@ import {
 } from '@fortawesome/free-solid-svg-icons';
 
 import TokenInputGroup from '../../components/TokenInputGroup';
-import useTokens, { getTokenBySymbol } from '../../lib/web3/hooks/useTokens';
+import useTokens, { useTokenBySymbol } from '../../lib/web3/hooks/useTokens';
 import RadioButtonGroupInput from '../../components/RadioButtonGroupInput/RadioButtonGroupInput';
 import NumberInput, {
   useNumericInputState,
@@ -56,15 +56,8 @@ function Swap() {
   // change tokens to match pathname
   const tokenList = useTokens();
   const match = useMatch('/swap/:tokenA/:tokenB');
-
-  const [tokenA, tokenB] = useMemo<[Token?, Token?]>(() => {
-    if (match) {
-      const tokenA = getTokenBySymbol(match.params['tokenA']);
-      const tokenB = getTokenBySymbol(match.params['tokenB']);
-      return [tokenA, tokenB];
-    }
-    return [];
-  }, [match]);
+  const tokenA = useTokenBySymbol(match?.params['tokenA']);
+  const tokenB = useTokenBySymbol(match?.params['tokenB']);
 
   // don't change tokens directly:
   // change the path name which will in turn update the tokens selected

--- a/src/pages/Swap/hooks/useSwap.tsx
+++ b/src/pages/Swap/hooks/useSwap.tsx
@@ -6,16 +6,13 @@ import { BigNumber } from 'bignumber.js';
 import { formatAmount } from '../../../lib/utils/number';
 import { useWeb3 } from '../../../lib/web3/useWeb3';
 
-import {
-  checkMsgErrorToast,
-  checkMsgOutOfGasToast,
-  checkMsgRejectedToast,
-  checkMsgSuccessToast,
-  createLoadingToast,
-} from '../../../components/Notifications/common';
+import { createTransactionToasts } from '../../../components/Notifications/common';
 
-import { addressableTokenMap } from '../../../lib/web3/hooks/useTokens';
 import { getAmountInDenom } from '../../../lib/web3/utils/tokens';
+import useTokens, {
+  matchTokenByAddress,
+  useTokensWithIbcInfo,
+} from '../../../lib/web3/hooks/useTokens';
 import {
   mapEventAttributes,
   CoinReceivedEvent,
@@ -46,7 +43,7 @@ async function sendSwap(
     receiver,
   }: MsgPlaceLimitOrder,
   gasEstimate: number
-): Promise<void> {
+): Promise<DeliverTxResponse> {
   if (!amountIn || !orderType || !tokenIn || !tokenOut || !creator) {
     throw new Error('Invalid Input');
   }
@@ -55,91 +52,27 @@ async function sendSwap(
     throw new Error('Invalid Input (0 value)');
   }
 
-  const tokenOutToken = addressableTokenMap[tokenOut];
-  if (!tokenOutToken) {
-    throw new Error('Invalid Output (token address not found)');
-  }
-
   // send message to chain
-
-  const id = `${Date.now()}.${Math.random}`;
-
-  createLoadingToast({ id, description: 'Executing your trade' });
-
   const client = await rpcClient(wallet);
-  return client
-    .signAndBroadcast(
-      address,
-      [
-        dualitylabs.duality.dex.MessageComposer.withTypeUrl.placeLimitOrder({
-          orderType,
-          tickIndex,
-          amountIn,
-          maxAmountOut,
-          tokenIn,
-          tokenOut,
-          creator,
-          receiver,
-        }),
-      ],
-      {
-        gas: gasEstimate.toFixed(0),
-        amount: [{ amount: (gasEstimate * 0.025).toFixed(0), denom: 'token' }],
-      }
-    )
-    .then(function (res): void {
-      if (!res) {
-        throw new Error('No response');
-      }
-      const { code } = res;
-
-      const amountOut = res.events.reduce<BigNumber>((result, event) => {
-        if (
-          event.type === 'coin_received' &&
-          event.attributes.find(
-            ({ key, value }) => key === 'receiver' && value === address
-          )
-        ) {
-          // collect into more usable format for parsing
-          const { attributes } = mapEventAttributes<CoinReceivedEvent>(event);
-          // parse coin string for matching tokens
-          const coin = parseCoins(attributes.amount)[0];
-          if (coin?.denom === tokenOut) {
-            return result.plus(coin?.amount || 0);
-          }
-        }
-        return result;
-      }, new BigNumber(0));
-
-      const description = amountOut
-        ? `Received ${formatAmount(
-            getAmountInDenom(
-              tokenOutToken,
-              amountOut?.toFixed() || '0',
-              tokenOutToken.address,
-              tokenOutToken.display
-            ) || '0'
-          )} ${tokenOutToken.symbol} (click for more details)`
-        : undefined;
-
-      if (!checkMsgSuccessToast(res, { id, description })) {
-        const error: Error & { response?: DeliverTxResponse } = new Error(
-          `Tx error: ${code}`
-        );
-        error.response = res;
-        throw error;
-      }
-    })
-    .catch(function (err: Error & { response?: DeliverTxResponse }) {
-      // catch transaction errors
-      // chain toast checks so only one toast may be shown
-      checkMsgRejectedToast(err, { id }) ||
-        checkMsgOutOfGasToast(err, { id }) ||
-        checkMsgErrorToast(err, { id });
-
-      // rethrow error
-      throw err;
-    });
+  return client.signAndBroadcast(
+    address,
+    [
+      dualitylabs.duality.dex.MessageComposer.withTypeUrl.placeLimitOrder({
+        orderType,
+        tickIndex,
+        amountIn,
+        maxAmountOut,
+        tokenIn,
+        tokenOut,
+        creator,
+        receiver,
+      }),
+    ],
+    {
+      gas: gasEstimate.toFixed(0),
+      amount: [{ amount: (gasEstimate * 0.025).toFixed(0), denom: 'token' }],
+    }
+  );
 }
 
 /**
@@ -159,6 +92,8 @@ export function useSwap(): [
   const [validating, setValidating] = useState(false);
   const [error, setError] = useState<string>();
   const web3 = useWeb3();
+
+  const tokens = useTokensWithIbcInfo(useTokens());
 
   const sendRequest = useCallback(
     (request: MsgPlaceLimitOrder, gasEstimate: number) => {
@@ -191,8 +126,51 @@ export function useSwap(): [
 
       const { wallet, address } = web3;
       if (!wallet || !address) return onError('Client has no wallet');
+      if (!tokens) return onError('Send not ready: token list not ready');
 
-      sendSwap({ wallet, address }, request, gasEstimate)
+      const tokenOutToken = tokens.find(matchTokenByAddress(tokenOut));
+      if (!tokenOutToken) return onError('Token out was not found');
+
+      createTransactionToasts(
+        () => {
+          return sendSwap({ wallet, address }, request, gasEstimate);
+        },
+        {
+          onLoadingMessage: 'Executing your trade',
+          onSuccess(res) {
+            const amountOut = res.events.reduce<BigNumber>((result, event) => {
+              if (
+                event.type === 'coin_received' &&
+                event.attributes.find(
+                  ({ key, value }) => key === 'receiver' && value === address
+                )
+              ) {
+                // collect into more usable format for parsing
+                const { attributes } =
+                  mapEventAttributes<CoinReceivedEvent>(event);
+                // parse coin string for matching tokens
+                const coin = parseCoins(attributes.amount)[0];
+                if (coin?.denom === tokenOut) {
+                  return result.plus(coin?.amount || 0);
+                }
+              }
+              return result;
+            }, new BigNumber(0));
+
+            const description = amountOut
+              ? `Received ${formatAmount(
+                  getAmountInDenom(
+                    tokenOutToken,
+                    amountOut?.toFixed() || '0',
+                    tokenOutToken.address,
+                    tokenOutToken.display
+                  ) || '0'
+                )} ${tokenOutToken.symbol} (click for more details)`
+              : undefined;
+            return { description };
+          },
+        }
+      )
         .then(function () {
           setValidating(false);
         })
@@ -209,7 +187,7 @@ export function useSwap(): [
         setError(message);
       }
     },
-    [web3]
+    [tokens, web3]
   );
 
   return [{ data, isValidating: validating, error }, sendRequest];


### PR DESCRIPTION
This PR refactors current usage to avoid references to
- `addressableTokenMap`
- `tokenListCache`

As they are static lists and cannot easily contain IBC token info (which is fetched upon application load). The usage should instead use hooks that update with IBC info when that information is available.