### PR TITLE
refactor: seperate denom amount getters

### DIFF
--- a/src/components/TokenInputGroup/TokenInputGroup.tsx
+++ b/src/components/TokenInputGroup/TokenInputGroup.tsx
@@ -5,7 +5,7 @@ import TokenPicker from '../TokenPicker';
 import { Token } from '../../lib/web3/utils/tokens';
 
 import NumberInput from '../inputs/NumberInput';
-import { useBankBigBalance } from '../../lib/web3/indexerProvider';
+import { useBankBalanceDisplayAmount } from '../../lib/web3/hooks/useUserBankBalances';
 import { useSimplePrice } from '../../lib/tokenPrices';
 import {
   formatAmount,
@@ -74,7 +74,7 @@ export default function TokenInputGroup({
     return '';
   }, [value, price]);
 
-  const { data: balance } = useBankBigBalance(token);
+  const { data: balance } = useBankBalanceDisplayAmount(token);
   const maxValue = givenMaxValue || balance;
   return (
     <div

--- a/src/components/TokenPicker/TokenPicker.tsx
+++ b/src/components/TokenPicker/TokenPicker.tsx
@@ -14,10 +14,9 @@ import BigNumber from 'bignumber.js';
 import { useFilteredTokenList } from './hooks';
 import { useDualityTokens } from '../../lib/web3/hooks/useTokens';
 import { Token } from '../../lib/web3/utils/tokens';
-import {
-  useBankBalances,
-  useBankBigBalance,
-} from '../../lib/web3/indexerProvider';
+import { useBankBalances } from '../../lib/web3/indexerProvider';
+import { useBankBalanceDisplayAmount } from '../../lib/web3/hooks/useUserBankBalances';
+
 import { useSimplePrice } from '../../lib/tokenPrices';
 import { formatAmount, formatCurrency } from '../../lib/utils/number';
 
@@ -96,7 +95,7 @@ export default function TokenPicker({
   const userList = useMemo(() => {
     return balances
       ? tokenList.filter((token) =>
-          balances.find((balance) => balance.denom === token.address)
+          balances.find((balance) => balance.token === token)
         )
       : [];
   }, [tokenList, balances]); // Todo: actually filter list to tokens in User's wallet
@@ -332,7 +331,7 @@ function TokenPickerItem({
   const address = token.address;
   const logos = token.logo_URIs;
   const isDisabled = !!exclusion?.address && exclusion?.address === address;
-  const { data: balance = 0 } = useBankBigBalance(token);
+  const { data: balance = 0 } = useBankBalanceDisplayAmount(token);
   const {
     data: [price = 0],
   } = useSimplePrice(Number(balance) ? [token] : []);

--- a/src/components/TokenPicker/TokenPicker.tsx
+++ b/src/components/TokenPicker/TokenPicker.tsx
@@ -5,7 +5,6 @@ import {
   useRef,
   useState,
   useId,
-  useMemo,
 } from 'react';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { faQuestionCircle } from '@fortawesome/free-solid-svg-icons';
@@ -14,7 +13,7 @@ import BigNumber from 'bignumber.js';
 import { useFilteredTokenList } from './hooks';
 import { useDualityTokens } from '../../lib/web3/hooks/useTokens';
 import { Token } from '../../lib/web3/utils/tokens';
-import { useBankBalances } from '../../lib/web3/indexerProvider';
+import useUserTokens from '../../lib/web3/hooks/useUserTokens';
 import { useBankBalanceDisplayAmount } from '../../lib/web3/hooks/useUserBankBalances';
 
 import { useSimplePrice } from '../../lib/tokenPrices';
@@ -91,14 +90,7 @@ export default function TokenPicker({
   const [selectedIndex, setSelectedIndex] = useState(0);
   const inputRef = useRef<HTMLInputElement>(null);
   const bodyRef = useRef<HTMLUListElement>(null);
-  const { data: balances } = useBankBalances();
-  const userList = useMemo(() => {
-    return balances
-      ? tokenList.filter((token) =>
-          balances.find((balance) => balance.token === token)
-        )
-      : [];
-  }, [tokenList, balances]); // Todo: actually filter list to tokens in User's wallet
+  const userList = useUserTokens();
   const [assetMode, setAssetMode] = useState<AssetModeType>(
     userList.length ? 'User' : 'Duality'
   );

--- a/src/components/cards/AssetsTableCard.tsx
+++ b/src/components/cards/AssetsTableCard.tsx
@@ -14,7 +14,7 @@ import { useFilteredTokenList } from '../../components/TokenPicker/hooks';
 import { dualityChain } from '../../lib/web3/hooks/useChains';
 
 import { formatAmount } from '../../lib/utils/number';
-import { Token, getAmountInDenom } from '../../lib/web3/utils/tokens';
+import { Token, getDisplayDenomAmount } from '../../lib/web3/utils/tokens';
 
 import './AssetsTableCard.scss';
 
@@ -189,12 +189,9 @@ function AssetRow({
       </td>
       <td>
         <div>
-          {`${formatAmount(
-            getAmountInDenom(token, amount, token.address, token.display) || '',
-            {
-              useGrouping: true,
-            }
-          )}`}
+          {`${formatAmount(getDisplayDenomAmount(token, amount) || '', {
+            useGrouping: true,
+          })}`}
         </div>
         <div className="subtext">
           {`$${formatAmount(value?.toFixed() || '', {

--- a/src/components/cards/BridgeCard.tsx
+++ b/src/components/cards/BridgeCard.tsx
@@ -24,7 +24,11 @@ import {
 import { minutes, nanoseconds } from '../../lib/utils/time';
 import { formatAddress } from '../../lib/web3/utils/address';
 import { formatAmount } from '../../lib/utils/number';
-import { Token, getAmountInDenom } from '../../lib/web3/utils/tokens';
+import {
+  Token,
+  getBaseDenomAmount,
+  getDisplayDenomAmount,
+} from '../../lib/web3/utils/tokens';
 
 import './BridgeCard.scss';
 
@@ -102,12 +106,7 @@ export default function BridgeCard({
         if (!from.chain.chain_id) {
           throw new Error('Source Chain not found');
         }
-        const amount = getAmountInDenom(
-          from,
-          value,
-          from.display,
-          from.address
-        );
+        const amount = getBaseDenomAmount(from, value);
         if (!amount || !Number(amount)) {
           throw new Error('Invalid Token Amount');
         }
@@ -137,7 +136,7 @@ export default function BridgeCard({
         if (!to.chain.chain_id) {
           throw new Error('Destination Chain not found');
         }
-        const amount = getAmountInDenom(to, value, to.display, to.address);
+        const amount = getBaseDenomAmount(to, value);
         if (!amount || !Number(amount)) {
           throw new Error('Invalid Token Amount');
         }
@@ -451,11 +450,9 @@ function BridgeButton({
   const hasAvailableBalance = useMemo(() => {
     return new BigNumber(value || 0).isLessThanOrEqualTo(
       token
-        ? getAmountInDenom(
+        ? getDisplayDenomAmount(
             token,
-            bankBalanceAvailable?.balance?.amount || 0,
-            token.base,
-            token.display
+            bankBalanceAvailable?.balance?.amount || 0
           ) || 0
         : 0
     );
@@ -522,12 +519,7 @@ function RemoteChainReserves({
           <div className="text-muted ml-auto">
             {bankBalanceAmount
               ? formatAmount(
-                  getAmountInDenom(
-                    token,
-                    bankBalanceAmount,
-                    token.base,
-                    token.display
-                  ) || 0,
+                  getDisplayDenomAmount(token, bankBalanceAmount) || 0,
                   { useGrouping: true }
                 )
               : '...'}
@@ -586,12 +578,7 @@ function LocalChainReserves({
       <div className="text-muted ml-auto">
         {allUserBankAssets
           ? formatAmount(
-              getAmountInDenom(
-                token,
-                userToken?.amount ?? 0,
-                token.base,
-                token.display
-              ) || 0,
+              getDisplayDenomAmount(token, userToken?.amount ?? 0) || 0,
               { useGrouping: true }
             )
           : '...'}

--- a/src/components/cards/PoolStakesTableCard.tsx
+++ b/src/components/cards/PoolStakesTableCard.tsx
@@ -26,7 +26,7 @@ import {
   formatDecimalPlaces,
   formatPercentage,
 } from '../../lib/utils/number';
-import { Token, getAmountInDenom } from '../../lib/web3/utils/tokens';
+import { Token, getDisplayDenomAmount } from '../../lib/web3/utils/tokens';
 
 import { usePoolDepositFilterForPair } from '../../lib/web3/hooks/useUserShares';
 import {
@@ -113,24 +113,14 @@ export default function MyPoolStakesTableCard<T extends string | number>({
         }
         // add amount A
         const amountA = Number(
-          getAmountInDenom(
-            tokenA,
-            tokenAContext?.userReserves || 0,
-            tokenA.address,
-            tokenA.display
-          ) || 0
+          getDisplayDenomAmount(tokenA, tokenAContext?.userReserves || 0) || 0
         );
         if (!isNaN(amountA) && amountA > 0) {
           acc.amountA.push(amountA);
         }
         // add amount B
         const amountB = Number(
-          getAmountInDenom(
-            tokenB,
-            tokenBContext?.userReserves || 0,
-            tokenB.address,
-            tokenB.display
-          ) || 0
+          getDisplayDenomAmount(tokenB, tokenBContext?.userReserves || 0) || 0
         );
         if (!isNaN(amountB) && amountB > 0) {
           acc.amountB.push(amountB);
@@ -533,11 +523,9 @@ function StakingRow({
             <div>
               <span>
                 {formatDecimalPlaces(
-                  getAmountInDenom(
+                  getDisplayDenomAmount(
                     tokenA,
-                    tokenAContext?.userReserves || 0,
-                    tokenA.address,
-                    tokenA.display
+                    tokenAContext?.userReserves || 0
                   ) || 0,
                   columnDecimalPlaces.amountA,
                   {
@@ -552,11 +540,9 @@ function StakingRow({
             <div>
               <span>
                 {formatDecimalPlaces(
-                  getAmountInDenom(
+                  getDisplayDenomAmount(
                     tokenB,
-                    tokenBContext?.userReserves || 0,
-                    tokenB.address,
-                    tokenB.display
+                    tokenBContext?.userReserves || 0
                   ) || 0,
                   columnDecimalPlaces.amountB,
                   {

--- a/src/components/cards/PoolsTableCard.tsx
+++ b/src/components/cards/PoolsTableCard.tsx
@@ -10,7 +10,7 @@ import { useFilteredTokenList } from '../../components/TokenPicker/hooks';
 import useTokens from '../../lib/web3/hooks/useTokens';
 
 import { formatAmount } from '../../lib/utils/number';
-import { Token, getAmountInDenom } from '../../lib/web3/utils/tokens';
+import { Token, getDisplayDenomAmount } from '../../lib/web3/utils/tokens';
 import useTokenPairs from '../../lib/web3/hooks/useTokenPairs';
 import { useTokenPairTickLiquidity } from '../../lib/web3/hooks/useTickLiquidity';
 import { getPairID } from '../../lib/web3/utils/pairs';
@@ -157,22 +157,14 @@ function PairRow({
       return [
         token0Ticks.reduce<BigNumber>((acc, tick) => {
           return acc.plus(
-            getAmountInDenom(
-              token0,
-              tick.reserve0.multipliedBy(price0),
-              token0.address,
-              token0.display
-            ) || 0
+            getDisplayDenomAmount(token0, tick.reserve0.multipliedBy(price0)) ||
+              0
           );
         }, initialValues[0]),
         token1Ticks.reduce<BigNumber>((acc, tick) => {
           return acc.plus(
-            getAmountInDenom(
-              token1,
-              tick.reserve1.multipliedBy(price1),
-              token1.address,
-              token1.display
-            ) || 0
+            getDisplayDenomAmount(token1, tick.reserve1.multipliedBy(price1)) ||
+              0
           );
         }, initialValues[1]),
       ];
@@ -424,24 +416,10 @@ function PositionRow({
         <td>{value0 && value1 && <>${value0.plus(value1).toFixed(2)}</>}</td>
         <td>
           <span className="token-compositions">
-            {formatAmount(
-              getAmountInDenom(
-                token0,
-                total0,
-                token0.address,
-                token0.display
-              ) || 0
-            )}
+            {formatAmount(getDisplayDenomAmount(token0, total0) || 0)}
             &nbsp;{token0.symbol}
             {' / '}
-            {formatAmount(
-              getAmountInDenom(
-                token1,
-                total1,
-                token1.address,
-                token1.display
-              ) || 0
-            )}
+            {formatAmount(getDisplayDenomAmount(token1, total1) || 0)}
             &nbsp;{token1.symbol}
           </span>
         </td>

--- a/src/lib/utils/number.ts
+++ b/src/lib/utils/number.ts
@@ -53,7 +53,7 @@ export function formatMaximumSignificantDecimals(
 // format to a visually pleasing output
 // should never be passed on to further calculations due to rounding
 // it is intended that the amount passed here has no more decimal places
-// than its denom exponent (eg. 18 set from a typical `getAmountInDenom()` call
+// than its denom exponent (eg. 18 set from a typical `getDisplayDenomAmount()`
 // or had its digits restricted with `formatMaximumSignificantDecimals()`)
 // this is because there is a conflict between setting fractionDigits and
 // significantDigits at the same time (which isn't resolved in any browser yet)
@@ -132,7 +132,7 @@ export function formatLongPrice(
 // format to a visually pleasing output of currency
 // should never be passed on to further calculations due to rounding
 // it is intended that the amount passed here has no more decimal places
-// than its denom exponent (eg. it has come from `getAmountInDenom()`)
+// than its denom exponent (eg. it has come from `getDisplayDenomAmount()`)
 export function formatCurrency(amount: number | string, currency = 'USD') {
   return Number(amount).toLocaleString('en-US', {
     currency,

--- a/src/lib/web3/hooks/useTokens.ts
+++ b/src/lib/web3/hooks/useTokens.ts
@@ -318,6 +318,12 @@ function defaultSort(a: Token, b: Token) {
   return a.symbol.localeCompare(b.symbol);
 }
 
+export function matchTokens(tokenA: Token, tokenB: Token) {
+  return (
+    tokenA.address === tokenB.address &&
+    tokenA.chain.chain_id === tokenB.chain.chain_id
+  );
+}
 // utility functions to get a matching token from a list
 export function matchTokenByAddress(address: TokenAddress) {
   return (token: Token) => token.address === address;

--- a/src/lib/web3/hooks/useUserBankBalances.ts
+++ b/src/lib/web3/hooks/useUserBankBalances.ts
@@ -1,6 +1,7 @@
 import { useMemo } from 'react';
 import { Token, getDenomAmount } from '../utils/tokens';
 import { useBankBalances } from '../indexerProvider';
+import { matchTokens } from './useTokens';
 
 // note: if dealing with IBC tokens, ensure Token has IBC context
 //       (by fetching it with useTokensWithIbcInfo)
@@ -8,7 +9,9 @@ function useBankBalance(token: Token | undefined) {
   const { data: balances, ...rest } = useBankBalances();
   const balance = useMemo(() => {
     // find the balance that matches the token
-    return token && balances?.find((balance) => balance.token === token);
+    return (
+      token && balances?.find((balance) => matchTokens(balance.token, token))
+    );
   }, [balances, token]);
   return { data: balance, ...rest };
 }

--- a/src/lib/web3/hooks/useUserBankBalances.ts
+++ b/src/lib/web3/hooks/useUserBankBalances.ts
@@ -1,0 +1,47 @@
+import { useMemo } from 'react';
+import { Token, getDenomAmount } from '../utils/tokens';
+import { useBankBalances } from '../indexerProvider';
+
+// note: if dealing with IBC tokens, ensure Token has IBC context
+//       (by fetching it with useTokensWithIbcInfo)
+function useBankBalance(token: Token | undefined) {
+  const { data: balances, ...rest } = useBankBalances();
+  const balance = useMemo(() => {
+    // find the balance that matches the token
+    return token && balances?.find((balance) => balance.token === token);
+  }, [balances, token]);
+  return { data: balance, ...rest };
+}
+
+// the bank balances may be in denoms that are neither base or display units
+// convert them to base or display units with the following handler functions
+export function useBankBalanceBaseAmount(token: Token | undefined) {
+  const { data: balance, ...rest } = useBankBalance(token);
+  const balanceAmount = useMemo(() => {
+    return (
+      balance &&
+      getDenomAmount(
+        balance.token,
+        balance.amount,
+        balance.denom,
+        balance.token.base
+      )
+    );
+  }, [balance]);
+  return { data: balanceAmount, ...rest };
+}
+export function useBankBalanceDisplayAmount(token: Token | undefined) {
+  const { data: balance, ...rest } = useBankBalance(token);
+  const balanceAmount = useMemo(() => {
+    return (
+      balance &&
+      getDenomAmount(
+        balance.token,
+        balance.amount,
+        balance.denom,
+        balance.token.display
+      )
+    );
+  }, [balance]);
+  return { data: balanceAmount, ...rest };
+}

--- a/src/lib/web3/hooks/useUserBankValues.ts
+++ b/src/lib/web3/hooks/useUserBankValues.ts
@@ -25,11 +25,10 @@ export function useUserBankValues(): TokenCoinWithValue[] {
       const { amount, denom, token } = balance;
       const tokenIndex = selectedTokens.indexOf(token);
       const price = selectedTokensPrices[tokenIndex];
+      const displayAmount = getDenomAmount(token, amount, denom, token.display);
       const value =
-        price !== undefined
-          ? new BigNumber(
-              getDenomAmount(token, amount, denom, token.display) || 0
-            ).multipliedBy(price)
+        price !== undefined && !isNaN(price)
+          ? new BigNumber(displayAmount || 0).multipliedBy(price)
           : undefined;
       // append value to balance
       return { amount, denom, token, value };

--- a/src/lib/web3/hooks/useUserBankValues.ts
+++ b/src/lib/web3/hooks/useUserBankValues.ts
@@ -1,55 +1,39 @@
-import { Coin } from '@duality-labs/dualityjs/types/codegen/cosmos/base/v1beta1/coin';
 import BigNumber from 'bignumber.js';
 import { useMemo } from 'react';
+
 import { Token, getDenomAmount } from '../utils/tokens';
-import { useBankBalances } from '../indexerProvider';
-import useTokens, {
-  useTokensWithIbcInfo,
-  matchTokenByDenom,
-} from './useTokens';
+import { TokenCoin, useBankBalances } from '../indexerProvider';
 import { useSimplePrice } from '../../tokenPrices';
 
-type TokenCoin = Coin & {
-  token: Token;
+type TokenCoinWithValue = TokenCoin & {
   value: BigNumber | undefined;
 };
 
 // get all the user's bank values (tokens that are not Duality Dex shares)
-export function useUserBankValues(): TokenCoin[] {
+export function useUserBankValues(): TokenCoinWithValue[] {
   const { data: balances } = useBankBalances();
 
-  const allTokens = useTokens();
-  const allTokensWithIBC = useTokensWithIbcInfo(allTokens);
+  // get matched tokens found in the user's balances
   const selectedTokens = useMemo<Token[]>(() => {
-    // note: this could be better: we are just finding the first match in the chain registry
-    // with that denom, but really it needs to check for chain id too
-    // ibc tokens will need to be checked here too
-    // this should probably live in the indexerData as we'll always want the filtered balances
-    return (balances || []).reduce<Token[]>((result, balance) => {
-      const token = allTokensWithIBC.find(matchTokenByDenom(balance.denom));
-      if (token) {
-        result.push(token);
-      }
-      return result;
-    }, []);
-  }, [balances, allTokensWithIBC]);
+    return (balances || []).map<Token>((balance) => balance.token);
+  }, [balances]);
 
   const { data: selectedTokensPrices } = useSimplePrice(selectedTokens);
 
-  return useMemo<TokenCoin[]>(() => {
-    return (balances || [])
-      .map(({ amount, denom }) => {
-        const tokenIndex = selectedTokens.findIndex(matchTokenByDenom(denom));
-        const token = selectedTokens[tokenIndex] as Token | undefined;
-        const price = selectedTokensPrices[tokenIndex];
-        const value =
-          token &&
-          new BigNumber(
-            getDenomAmount(token, amount, denom, token.display) || 0
-          ).multipliedBy(price || 0);
-        return token ? { amount, denom, token, value } : null;
-      })
-      .filter((v): v is TokenCoin => !!v);
+  return useMemo<TokenCoinWithValue[]>(() => {
+    return (balances || []).map((balance) => {
+      const { amount, denom, token } = balance;
+      const tokenIndex = selectedTokens.indexOf(token);
+      const price = selectedTokensPrices[tokenIndex];
+      const value =
+        price !== undefined
+          ? new BigNumber(
+              getDenomAmount(token, amount, denom, token.display) || 0
+            ).multipliedBy(price)
+          : undefined;
+      // append value to balance
+      return { amount, denom, token, value };
+    });
   }, [balances, selectedTokens, selectedTokensPrices]);
 }
 

--- a/src/lib/web3/hooks/useUserBankValues.ts
+++ b/src/lib/web3/hooks/useUserBankValues.ts
@@ -1,7 +1,7 @@
 import { Coin } from '@duality-labs/dualityjs/types/codegen/cosmos/base/v1beta1/coin';
 import BigNumber from 'bignumber.js';
 import { useMemo } from 'react';
-import { Token, getAmountInDenom } from '../utils/tokens';
+import { Token, getDenomAmount } from '../utils/tokens';
 import { useBankBalances } from '../indexerProvider';
 import useTokens, {
   useTokensWithIbcInfo,
@@ -45,7 +45,7 @@ export function useUserBankValues(): TokenCoin[] {
         const value =
           token &&
           new BigNumber(
-            getAmountInDenom(token, amount, denom, token.display) || 0
+            getDenomAmount(token, amount, denom, token.display) || 0
           ).multipliedBy(price || 0);
         return token ? { amount, denom, token, value } : null;
       })

--- a/src/lib/web3/hooks/useUserShareValues.ts
+++ b/src/lib/web3/hooks/useUserShareValues.ts
@@ -2,7 +2,7 @@ import BigNumber from 'bignumber.js';
 import { useMemo } from 'react';
 import useTokens from './useTokens';
 import { useSimplePrice } from '../../tokenPrices';
-import { Token, getAmountInDenom } from '../utils/tokens';
+import { Token, getDisplayDenomAmount } from '../utils/tokens';
 import {
   ShareValueContext,
   UserDepositFilter,
@@ -90,12 +90,7 @@ export function useUserPositionsShareValues(
       const price = selectedTokensPriceMap[tokenAddress];
       if (token && price && !isNaN(price)) {
         // how many tokens does the user have?
-        const amount = getAmountInDenom(
-          token,
-          userReserves,
-          token.address,
-          token.display
-        );
+        const amount = getDisplayDenomAmount(token, userReserves);
         // how much are those tokens worth?
         const value = new BigNumber(amount || 0).multipliedBy(price);
         return value;

--- a/src/lib/web3/hooks/useUserTokens.ts
+++ b/src/lib/web3/hooks/useUserTokens.ts
@@ -1,16 +1,18 @@
 import { useMemo } from 'react';
-import useTokens from './useTokens';
-import { useUserBankValues } from './useUserBankValues';
+import useTokens, { matchTokens, useTokensWithIbcInfo } from './useTokens';
+import { useBankBalances } from '../indexerProvider';
 
 export default function useUserTokens() {
-  const tokenList = useTokens();
+  const tokenList = useTokensWithIbcInfo(useTokens());
 
-  const allUserBankAssets = useUserBankValues();
+  const { data: balances } = useBankBalances();
   return useMemo(() => {
-    return tokenList.filter((token) => {
-      return allUserBankAssets.find((userToken) => {
-        return userToken.token === token;
-      });
-    });
-  }, [tokenList, allUserBankAssets]);
+    return balances
+      ? tokenList.filter((token) => {
+          return balances.find((balance) => {
+            return matchTokens(balance.token, token);
+          });
+        })
+      : [];
+  }, [tokenList, balances]);
 }

--- a/src/lib/web3/hooks/useUserTokens.ts
+++ b/src/lib/web3/hooks/useUserTokens.ts
@@ -1,18 +1,9 @@
 import { useMemo } from 'react';
-import useTokens, { matchTokens, useTokensWithIbcInfo } from './useTokens';
 import { useBankBalances } from '../indexerProvider';
 
 export default function useUserTokens() {
-  const tokenList = useTokensWithIbcInfo(useTokens());
-
   const { data: balances } = useBankBalances();
   return useMemo(() => {
-    return balances
-      ? tokenList.filter((token) => {
-          return balances.find((balance) => {
-            return matchTokens(balance.token, token);
-          });
-        })
-      : [];
-  }, [tokenList, balances]);
+    return balances?.map((balance) => balance.token) ?? [];
+  }, [balances]);
 }

--- a/src/lib/web3/indexerProvider.tsx
+++ b/src/lib/web3/indexerProvider.tsx
@@ -20,7 +20,7 @@ import useTokenPairs from './hooks/useTokenPairs';
 
 import { feeTypes } from './utils/fees';
 
-import { Token, TokenAddress, getAmountInDenom } from './utils/tokens';
+import { Token, TokenAddress, getDenomAmount } from './utils/tokens';
 import { IndexedShare, getShareInfo } from './utils/shares';
 import { PairIdString, getPairID } from './utils/pairs';
 
@@ -400,7 +400,7 @@ export function useBankBigBalance(token: Token | undefined) {
     return (
       token &&
       foundBalance &&
-      getAmountInDenom(
+      getDenomAmount(
         token,
         foundBalance.amount,
         foundBalance.denom,

--- a/src/lib/web3/utils/tokens.ts
+++ b/src/lib/web3/utils/tokens.ts
@@ -26,7 +26,7 @@ export function getTokenAddressPair(
   return [getTokenAddress(token0), getTokenAddress(token1)];
 }
 
-export function getAmountInDenom(
+export function getDenomAmount(
   token: Token,
   amount: BigNumber.Value,
   // default to minimum denomination output
@@ -70,6 +70,37 @@ export function getAmountInDenom(
   }
 }
 
+export function getDisplayDenomAmount(
+  token: Token,
+  amount: BigNumber.Value,
+  options: {
+    fractionalDigits?: number;
+    // should we display more digits if there is not enough resolution to see?
+    significantDigits?: number;
+  } = {}
+): string | undefined {
+  return getDenomAmount(token, amount, token.base, token.display, options);
+}
+
+export function getBaseDenomAmount(
+  token: Token,
+  amount: BigNumber.Value,
+  {
+    fractionalDigits = 0,
+    // so digits forcibly past fractional digits
+    significantDigits,
+  }: {
+    fractionalDigits?: number;
+    // should we display more digits if there is not enough resolution to see?
+    significantDigits?: number;
+  } = {}
+): string | undefined {
+  return getDenomAmount(token, amount, token.display, token.base, {
+    fractionalDigits,
+    significantDigits,
+  });
+}
+
 // get how much a utoken amount is worth in USD
 export function getTokenValue(
   token: Token,
@@ -79,9 +110,7 @@ export function getTokenValue(
   if (price === undefined || amount === undefined) {
     return undefined;
   }
-  return new BigNumber(
-    getAmountInDenom(token, amount, token.address, token.display) || 0
-  )
+  return new BigNumber(getDisplayDenomAmount(token, amount) || 0)
     .multipliedBy(price || 0)
     .toNumber();
 }

--- a/src/pages/MyLiquidity/useEditLiquidity.ts
+++ b/src/pages/MyLiquidity/useEditLiquidity.ts
@@ -10,7 +10,7 @@ import {
   checkMsgSuccessToast,
   createLoadingToast,
 } from '../../components/Notifications/common';
-import { getAmountInDenom } from '../../lib/web3/utils/tokens';
+import { getBaseDenomAmount } from '../../lib/web3/utils/tokens';
 
 import { UserPositionDepositContext } from '../../lib/web3/hooks/useUserShares';
 import rpcClient from '../../lib/web3/rpcMsgClient';
@@ -151,11 +151,8 @@ export function useEditLiquidity(): [
                                       tickIndexesAToB: [centerTickIndex1To0],
                                       fees: [fee],
                                       amountsA: [
-                                        getAmountInDenom(
-                                          token0,
-                                          tickDiff0,
-                                          token0.display
-                                        ) || '0',
+                                        getBaseDenomAmount(token0, tickDiff0) ||
+                                          '0',
                                       ],
                                       amountsB: ['0'],
                                       // todo: allow user to specify autoswap behavior
@@ -201,11 +198,8 @@ export function useEditLiquidity(): [
                                       fees: [fee],
                                       amountsA: ['0'],
                                       amountsB: [
-                                        getAmountInDenom(
-                                          token1,
-                                          tickDiff1,
-                                          token1.display
-                                        ) || '0',
+                                        getBaseDenomAmount(token1, tickDiff1) ||
+                                          '0',
                                       ],
                                       // todo: allow user to specify autoswap behavior
                                       Options: [{ disable_autoswap: false }],

--- a/src/pages/Pool/MyPositionTableCard.tsx
+++ b/src/pages/Pool/MyPositionTableCard.tsx
@@ -4,7 +4,7 @@ import { Tick } from '../../components/LiquiditySelector/LiquiditySelector';
 
 import { formatCurrency } from '../../lib/utils/number';
 import { tickIndexToPrice } from '../../lib/web3/utils/ticks';
-import { Token, getAmountInDenom } from '../../lib/web3/utils/tokens';
+import { Token, getDisplayDenomAmount } from '../../lib/web3/utils/tokens';
 
 import { EditedPosition } from '../MyLiquidity/useEditLiquidity';
 import { guessInvertedOrder } from '../../lib/web3/utils/pairs';
@@ -86,26 +86,12 @@ export function MyNewPositionTableCard({
         const valueA =
           (priceA || 0) *
           new BigNumber(
-            (reserveA &&
-              getAmountInDenom(
-                tokenA,
-                reserveA || 0,
-                tokenA.address,
-                tokenA.display
-              )) ||
-              0
+            (reserveA && getDisplayDenomAmount(tokenA, reserveA || 0)) || 0
           ).toNumber();
         const valueB =
           (priceB || 0) *
           new BigNumber(
-            (reserveB &&
-              getAmountInDenom(
-                tokenB,
-                reserveB || 0,
-                tokenB.address,
-                tokenB.display
-              )) ||
-              0
+            (reserveB && getDisplayDenomAmount(tokenB, reserveB || 0)) || 0
           ).toNumber();
         return [valueA, valueB];
       }
@@ -257,11 +243,9 @@ export function MyEditedPositionTableCard({
           (priceA || 0) *
           new BigNumber(
             (tokenAContext?.userReserves &&
-              getAmountInDenom(
+              getDisplayDenomAmount(
                 tokenA,
-                tokenAContext?.userReserves || 0,
-                tokenA.address,
-                tokenA.display
+                tokenAContext?.userReserves || 0
               )) ||
               0
           ).toNumber();
@@ -269,11 +253,9 @@ export function MyEditedPositionTableCard({
           (priceB || 0) *
           new BigNumber(
             (tokenBContext?.userReserves &&
-              getAmountInDenom(
+              getDisplayDenomAmount(
                 tokenB,
-                tokenBContext?.userReserves || 0,
-                tokenB.address,
-                tokenB.display
+                tokenBContext?.userReserves || 0
               )) ||
               0
           ).toNumber();
@@ -461,7 +443,7 @@ function formatReserveAmount(
   fractionalDigits = 3
 ) {
   return reserve.isGreaterThan(1e-5)
-    ? getAmountInDenom(token, reserve, token.address, token.display, {
+    ? getDisplayDenomAmount(token, reserve, {
         fractionalDigits,
       })
     : '';

--- a/src/pages/Pool/PoolManagement.tsx
+++ b/src/pages/Pool/PoolManagement.tsx
@@ -50,7 +50,11 @@ import {
 import { priceToTickIndex, tickIndexToPrice } from '../../lib/web3/utils/ticks';
 import { FeeType, feeTypes } from '../../lib/web3/utils/fees';
 import { LiquidityShape, liquidityShapes } from '../../lib/web3/utils/shape';
-import { Token, getAmountInDenom } from '../../lib/web3/utils/tokens';
+import {
+  Token,
+  getBaseDenomAmount,
+  getDisplayDenomAmount,
+} from '../../lib/web3/utils/tokens';
 
 import './Pool.scss';
 import RadioInput from '../../components/RadioInput';
@@ -173,12 +177,8 @@ export default function PoolManagement({
   // convert input value text to correct denom values
   const values = useMemo(
     (): [string, string] => [
-      (tokenA &&
-        getAmountInDenom(tokenA, valueA, tokenA.display, tokenA.address)) ||
-        '0',
-      (tokenB &&
-        getAmountInDenom(tokenB, valueB, tokenB.display, tokenB.address)) ||
-        '0',
+      (tokenA && getBaseDenomAmount(tokenA, valueA)) || '0',
+      (tokenB && getBaseDenomAmount(tokenB, valueB)) || '0',
     ],
     [tokenA, tokenB, valueA, valueB]
   );
@@ -695,24 +695,20 @@ export default function PoolManagement({
     if (tokenA && tokenB && feeType) {
       if (lastUsedInput === 'A') {
         // convert back to display units
-        const amountB = getAmountInDenom(
+        const amountB = getDisplayDenomAmount(
           tokenB,
           shapeReservesArray.reduce((acc, [tickInddex, reserveA, reserveB]) => {
             return acc.plus(reserveB);
-          }, new BigNumber(0)),
-          tokenB.address,
-          tokenB.display
+          }, new BigNumber(0))
         );
         setInputValueB(amountB ? formatAmount(amountB) : '');
       } else if (lastUsedInput === 'B') {
         // convert back to display units
-        const amountA = getAmountInDenom(
+        const amountA = getDisplayDenomAmount(
           tokenA,
           shapeReservesArray.reduce((acc, [tickInddex, reserveA, reserveB]) => {
             return acc.plus(reserveA);
-          }, new BigNumber(0)),
-          tokenA.address,
-          tokenA.display
+          }, new BigNumber(0))
         );
         setInputValueA(amountA ? formatAmount(amountA) : '');
       }
@@ -1092,12 +1088,8 @@ export default function PoolManagement({
                 </div>
                 <div className="col ml-auto">
                   {formatAmount(
-                    getAmountInDenom(
-                      tokenA,
-                      diffA.negated().toNumber(),
-                      tokenA.address,
-                      tokenA.display
-                    ) || 0
+                    getDisplayDenomAmount(tokenA, diffA.negated().toNumber()) ||
+                      0
                   )}{' '}
                   {tokenA.symbol}
                 </div>
@@ -1110,12 +1102,8 @@ export default function PoolManagement({
                 </div>
                 <div className="col ml-auto">
                   {formatAmount(
-                    getAmountInDenom(
-                      tokenB,
-                      diffB.negated().toNumber(),
-                      tokenB.address,
-                      tokenB.display
-                    ) || 0
+                    getDisplayDenomAmount(tokenB, diffB.negated().toNumber()) ||
+                      0
                   )}{' '}
                   {tokenB.symbol}
                 </div>
@@ -1128,12 +1116,7 @@ export default function PoolManagement({
                 </div>
                 <div className="col ml-auto">
                   {formatAmount(
-                    getAmountInDenom(
-                      tokenA,
-                      diffA.toNumber(),
-                      tokenA.address,
-                      tokenA.display
-                    ) || 0
+                    getDisplayDenomAmount(tokenA, diffA.toNumber()) || 0
                   )}{' '}
                   {tokenA.symbol}
                 </div>
@@ -1146,12 +1129,7 @@ export default function PoolManagement({
                 </div>
                 <div className="col ml-auto">
                   {formatAmount(
-                    getAmountInDenom(
-                      tokenB,
-                      diffB.toNumber(),
-                      tokenB.address,
-                      tokenB.display
-                    ) || 0
+                    getDisplayDenomAmount(tokenB, diffB.toNumber()) || 0
                   )}{' '}
                   {tokenB.symbol}
                 </div>
@@ -1179,11 +1157,9 @@ export default function PoolManagement({
               {tokenA && !diffTokenA.isZero() && (
                 <div className="ml-auto">
                   {formatAmount(
-                    getAmountInDenom(
+                    getDisplayDenomAmount(
                       tokenA,
-                      diffTokenA.negated().toNumber(),
-                      tokenA.address,
-                      tokenA.display
+                      diffTokenA.negated().toNumber()
                     ) || 0
                   )}{' '}
                   {tokenA.symbol}
@@ -1192,11 +1168,9 @@ export default function PoolManagement({
               {tokenB && !diffTokenB.isZero() && (
                 <div className="ml-auto">
                   {formatAmount(
-                    getAmountInDenom(
+                    getDisplayDenomAmount(
                       tokenB,
-                      diffTokenB.negated().toNumber(),
-                      tokenB.address,
-                      tokenB.display
+                      diffTokenB.negated().toNumber()
                     ) || 0
                   )}{' '}
                   {tokenB.symbol}

--- a/src/pages/Pool/PoolManagement.tsx
+++ b/src/pages/Pool/PoolManagement.tsx
@@ -17,7 +17,7 @@ import {
   faMagnifyingGlassMinus,
 } from '@fortawesome/free-solid-svg-icons';
 
-import { useBankBalance } from '../../lib/web3/indexerProvider';
+import { useBankBalanceBaseAmount } from '../../lib/web3/hooks/useUserBankBalances';
 
 import SelectInput, { OptionProps } from '../../components/inputs/SelectInput';
 import StepNumberInput from '../../components/StepNumberInput';
@@ -740,8 +740,8 @@ export default function PoolManagement({
     feeType,
   ]);
 
-  const { data: balanceTokenA } = useBankBalance(tokenA);
-  const { data: balanceTokenB } = useBankBalance(tokenB);
+  const { data: balanceTokenA } = useBankBalanceBaseAmount(tokenA);
+  const { data: balanceTokenB } = useBankBalanceBaseAmount(tokenB);
 
   // compare with BigNumber to avoid float imprecision
   const hasSufficientFundsA =

--- a/src/pages/Pool/PoolOverview.tsx
+++ b/src/pages/Pool/PoolOverview.tsx
@@ -13,7 +13,7 @@ import { SmallCardRow } from '../../components/cards/SmallCard';
 import StatCardTVL from '../../components/stats/StatCardTVL';
 
 import { formatAddress } from '../../lib/web3/utils/address';
-import { Token, getAmountInDenom } from '../../lib/web3/utils/tokens';
+import { Token, getDisplayDenomAmount } from '../../lib/web3/utils/tokens';
 import {
   getPairID,
   guessInvertedOrder,
@@ -179,11 +179,9 @@ function PairComposition({ tokenA, tokenB }: { tokenA: Token; tokenB: Token }) {
           return (
             <td>
               {formatAmount(
-                getAmountInDenom(
+                getDisplayDenomAmount(
                   token,
-                  token === tokenA ? amountA : amountB,
-                  token.address,
-                  token.display
+                  token === tokenA ? amountA : amountB
                 ) || 0
               )}
             </td>
@@ -695,20 +693,10 @@ function EventColumn<
       case 'Total Value':
         const values = [
           new BigNumber(
-            getAmountInDenom(
-              tokenA,
-              getTokenAReserves(),
-              tokenA.address,
-              tokenA.display
-            ) || 0
+            getDisplayDenomAmount(tokenA, getTokenAReserves()) || 0
           ).multipliedBy(tokenAPrice || 0),
           new BigNumber(
-            getAmountInDenom(
-              tokenB,
-              getTokenBReserves(),
-              tokenB.address,
-              tokenB.display
-            ) || 0
+            getDisplayDenomAmount(tokenB, getTokenBReserves()) || 0
           ).multipliedBy(tokenBPrice || 0),
         ];
         const value = values[0].plus(values[1]);
@@ -750,7 +738,7 @@ function EventColumn<
     }
 
     function getTokenReservesInDenom(token: Token, reserves: string) {
-      return getAmountInDenom(token, reserves, token.address, token.display, {
+      return getDisplayDenomAmount(token, reserves, {
         fractionalDigits: 3,
         significantDigits: 3,
       });
@@ -846,20 +834,10 @@ function SwapColumn({
       case 'Total Value':
         const values = [
           new BigNumber(
-            getAmountInDenom(
-              tokenA,
-              getTokenAReserves(),
-              tokenA.address,
-              tokenA.display
-            ) || 0
+            getDisplayDenomAmount(tokenA, getTokenAReserves()) || 0
           ).multipliedBy(tokenAPrice || 0),
           new BigNumber(
-            getAmountInDenom(
-              tokenB,
-              getTokenBReserves(),
-              tokenB.address,
-              tokenB.display
-            ) || 0
+            getDisplayDenomAmount(tokenB, getTokenBReserves()) || 0
           ).multipliedBy(tokenBPrice || 0),
         ];
         const value = values[0].plus(values[1]);
@@ -891,7 +869,7 @@ function SwapColumn({
     }
 
     function getTokenReservesInDenom(token: Token, reserves: BigNumber.Value) {
-      return getAmountInDenom(token, reserves, token.address, token.display, {
+      return getDisplayDenomAmount(token, reserves, {
         fractionalDigits: 3,
         significantDigits: 3,
       });

--- a/src/pages/Pool/useDeposit.ts
+++ b/src/pages/Pool/useDeposit.ts
@@ -14,7 +14,7 @@ import {
   checkMsgSuccessToast,
   createLoadingToast,
 } from '../../components/Notifications/common';
-import { Token, getAmountInDenom } from '../../lib/web3/utils/tokens';
+import { Token, getDisplayDenomAmount } from '../../lib/web3/utils/tokens';
 import {
   DexDepositEvent,
   mapEventAttributes,
@@ -373,21 +373,11 @@ export function useDeposit([tokenA, tokenB]: [
               description: `Deposited ${[
                 receivedTokenA.isGreaterThan(0) &&
                   `${formatAmount(
-                    getAmountInDenom(
-                      tokenA,
-                      receivedTokenA,
-                      tokenA.address,
-                      tokenA.display
-                    ) || 0
+                    getDisplayDenomAmount(tokenA, receivedTokenA) || 0
                   )} ${tokenA.symbol}`,
                 receivedTokenB.isGreaterThan(0) &&
                   `${formatAmount(
-                    getAmountInDenom(
-                      tokenB,
-                      receivedTokenB,
-                      tokenB.address,
-                      tokenB.display
-                    ) || 0
+                    getDisplayDenomAmount(tokenB, receivedTokenB) || 0
                   )} ${tokenB.symbol}`,
               ]
                 .filter(Boolean)

--- a/src/pages/Swap/Swap.tsx
+++ b/src/pages/Swap/Swap.tsx
@@ -28,7 +28,7 @@ import { getRouterEstimates, useRouterResult } from './hooks/useRouter';
 import { useSwap } from './hooks/useSwap';
 
 import { formatAmount } from '../../lib/utils/number';
-import { Token, getAmountInDenom } from '../../lib/web3/utils/tokens';
+import { Token, getBaseDenomAmount } from '../../lib/web3/utils/tokens';
 import { formatLongPrice } from '../../lib/utils/number';
 
 import './Swap.scss';
@@ -219,8 +219,7 @@ function Swap() {
 
         swapRequest(
           {
-            amountIn:
-              getAmountInDenom(tokenA, result.amountIn, tokenA?.display) || '0',
+            amountIn: getBaseDenomAmount(tokenA, result.amountIn) || '0',
             tokenIn: result.tokenIn,
             tokenOut: result.tokenOut,
             creator: address,
@@ -235,9 +234,7 @@ function Swap() {
             // todo: set tickIndex to allow for a tolerance:
             //   the below function is a tolerance of 0
             tickIndex: Long.fromNumber(tickIndexLimit * (forward ? 1 : -1)),
-            maxAmountOut:
-              getAmountInDenom(tokenB, result.amountOut, tokenB?.display) ||
-              '0',
+            maxAmountOut: getBaseDenomAmount(tokenB, result.amountOut) || '0',
           },
           gasEstimate
         );

--- a/src/pages/Swap/Swap.tsx
+++ b/src/pages/Swap/Swap.tsx
@@ -20,7 +20,7 @@ import NumberInput, {
 import PriceDataDisclaimer from '../../components/PriceDataDisclaimer';
 
 import { useWeb3 } from '../../lib/web3/useWeb3';
-import { useBankBigBalance } from '../../lib/web3/indexerProvider';
+import { useBankBalanceDisplayAmount } from '../../lib/web3/hooks/useUserBankBalances';
 import { useOrderedTokenPair } from '../../lib/web3/hooks/useTokenPairs';
 import { useTokenPairTickLiquidity } from '../../lib/web3/hooks/useTickLiquidity';
 
@@ -130,7 +130,7 @@ function Swap() {
     ]
   );
 
-  const { data: balanceTokenA } = useBankBigBalance(tokenA);
+  const { data: balanceTokenA } = useBankBalanceDisplayAmount(tokenA);
   const valueAConvertedNumber = new BigNumber(valueAConverted || 0);
   const hasFormData =
     address && tokenA && tokenB && valueAConvertedNumber.isGreaterThan(0);

--- a/src/pages/Swap/hooks/useRouter.ts
+++ b/src/pages/Swap/hooks/useRouter.ts
@@ -4,9 +4,12 @@ import { routerAsync, calculateFee, SwapError } from './router';
 import { formatAmount } from '../../../lib/utils/number';
 
 import BigNumber from 'bignumber.js';
-import { getAmountInDenom } from '../../../lib/web3/utils/tokens';
-import { useToken } from '../../../lib/web3/hooks/useTokens';
+import {
+  getBaseDenomAmount,
+  getDisplayDenomAmount,
+} from '../../../lib/web3/utils/tokens';
 
+import { useToken } from '../../../lib/web3/hooks/useTokens';
 import { useTokenPairTickLiquidity } from '../../../lib/web3/hooks/useTickLiquidity';
 import { useOrderedTokenPair } from '../../../lib/web3/hooks/useTokenPairs';
 import { TickInfo } from '../../../lib/web3/utils/ticks';
@@ -95,11 +98,7 @@ export function useRouterResult(pairRequest: PairRequest): {
     setData(undefined);
     setError(undefined);
     // convert token request down into base denom
-    const alteredValue = getAmountInDenom(
-      tokenA,
-      pairRequest.valueA || 0,
-      tokenA.display
-    );
+    const alteredValue = getBaseDenomAmount(tokenA, pairRequest.valueA || 0);
     const reverseSwap = !!pairRequest.valueB;
     if (!alteredValue || alteredValue === '0') {
       setIsValidating(false);
@@ -147,11 +146,9 @@ export function useRouterResult(pairRequest: PairRequest): {
         amountIn: new BigNumber(pairRequest.valueA || 0),
         amountOut: new BigNumber(
           (tokenB &&
-            getAmountInDenom(
+            getDisplayDenomAmount(
               tokenB,
-              result.amountOut.decimalPlaces(0, BigNumber.ROUND_DOWN),
-              tokenB.address,
-              tokenB.display
+              result.amountOut.decimalPlaces(0, BigNumber.ROUND_DOWN)
             )) ||
             0
         ),

--- a/src/pages/Swap/hooks/useSwap.tsx
+++ b/src/pages/Swap/hooks/useSwap.tsx
@@ -8,7 +8,7 @@ import { useWeb3 } from '../../../lib/web3/useWeb3';
 
 import { createTransactionToasts } from '../../../components/Notifications/common';
 
-import { getAmountInDenom } from '../../../lib/web3/utils/tokens';
+import { getDisplayDenomAmount } from '../../../lib/web3/utils/tokens';
 import useTokens, {
   matchTokenByAddress,
   useTokensWithIbcInfo,
@@ -159,11 +159,9 @@ export function useSwap(): [
 
             const description = amountOut
               ? `Received ${formatAmount(
-                  getAmountInDenom(
+                  getDisplayDenomAmount(
                     tokenOutToken,
-                    amountOut?.toFixed() || '0',
-                    tokenOutToken.address,
-                    tokenOutToken.display
+                    amountOut?.toFixed() || '0'
                   ) || '0'
                 )} ${tokenOutToken.symbol} (click for more details)`
               : undefined;


### PR DESCRIPTION
this PR separates out 
`getAmountInDenom` into 
- general: `getDenomAmount`
- `getBaseDenomAmount`
- `getDisplayDenomAmount`

This also allow us to add more helpful specific hooks
`useBankBigBalance` becomes:
- `useBankBalanceBaseAmount`
- `useBankBalanceDisplayAmount`

for specific use cases of a user's bank denom balance
