### PR TITLE
feat: better minimum value formatting

### DIFF
--- a/src/components/LiquiditySelector/LiquiditySelector.tsx
+++ b/src/components/LiquiditySelector/LiquiditySelector.tsx
@@ -1286,6 +1286,9 @@ function TicksArea({
             {
               minimumSignificantDigits: significantDecimals,
               useGrouping: true,
+            },
+            {
+              reformatSmallValues: false,
             }
           )}
           &nbsp;
@@ -1398,6 +1401,9 @@ function TicksArea({
             {
               minimumSignificantDigits: significantDecimals,
               useGrouping: true,
+            },
+            {
+              reformatSmallValues: false,
             }
           )}
           &nbsp;

--- a/src/components/LiquiditySelector/LiquiditySelector.tsx
+++ b/src/components/LiquiditySelector/LiquiditySelector.tsx
@@ -1286,8 +1286,7 @@ function TicksArea({
             {
               minimumSignificantDigits: significantDecimals,
               useGrouping: true,
-            },
-            0
+            }
           )}
           &nbsp;
         </text>

--- a/src/components/LiquiditySelector/LiquiditySelector.tsx
+++ b/src/components/LiquiditySelector/LiquiditySelector.tsx
@@ -17,6 +17,7 @@ import {
   formatPrice,
   formatMaximumSignificantDecimals,
   roundToSignificantDigits,
+  formatPercentage,
 } from '../../lib/utils/number';
 import { Token } from '../../lib/web3/utils/tokens';
 import { useOrderedTokenPair } from '../../lib/web3/hooks/useTokenPairs';
@@ -1200,18 +1201,16 @@ function TicksArea({
 
   const formatPercentageValue = useCallback(
     (tickIndex: number, currentPriceIndex: number) => {
-      return formatAmount(
-        formatMaximumSignificantDecimals(
-          tickIndexToPrice(new BigNumber(tickIndex))
-            .multipliedBy(100)
-            .dividedBy(tickIndexToPrice(new BigNumber(currentPriceIndex)))
-            .minus(100),
-          2
-        ),
+      return formatPercentage(
+        tickIndexToPrice(new BigNumber(tickIndex))
+          .dividedBy(tickIndexToPrice(new BigNumber(currentPriceIndex)))
+          .minus(1)
+          .toFixed(),
         {
           signDisplay: 'always',
           useGrouping: true,
-        }
+        },
+        2
       );
     },
     []
@@ -1287,7 +1286,8 @@ function TicksArea({
             {
               minimumSignificantDigits: significantDecimals,
               useGrouping: true,
-            }
+            },
+            0
           )}
           &nbsp;
         </text>
@@ -1301,13 +1301,13 @@ function TicksArea({
             textAnchor="end"
           >
             &nbsp;&nbsp;&nbsp;
-            {`${formatPercentageValue(
+            {formatPercentageValue(
               // show percentage to this limit index line (inclusive)
               rangeMinValueIndex <= Math.round(currentPriceIndex)
                 ? rangeMinValueIndex - 1
                 : rangeMinValueIndex,
               currentPriceIndex
-            )}%`}
+            )}
             &nbsp;&nbsp;&nbsp;
           </text>
         )}
@@ -1413,13 +1413,13 @@ function TicksArea({
             textAnchor="start"
           >
             &nbsp;&nbsp;&nbsp;
-            {`${formatPercentageValue(
+            {formatPercentageValue(
               // show percentage to this limit index line (inclusive)
               rangeMaxValueIndex >= Math.round(currentPriceIndex)
                 ? rangeMaxValueIndex + 1
                 : rangeMaxValueIndex,
               currentPriceIndex
-            )}%`}
+            )}
             &nbsp;&nbsp;&nbsp;
           </text>
         )}

--- a/src/components/TokenInputGroup/TokenInputGroup.tsx
+++ b/src/components/TokenInputGroup/TokenInputGroup.tsx
@@ -83,7 +83,6 @@ export default function TokenInputGroup({
         <h5 className="token-group-title">
           Available{' '}
           {formatAmount(maxValue, {
-            maximumSignificantDigits: 9,
             useGrouping: true,
           })}
         </h5>

--- a/src/components/TokenInputGroup/TokenInputGroup.tsx
+++ b/src/components/TokenInputGroup/TokenInputGroup.tsx
@@ -2,21 +2,14 @@ import React, { useCallback, useMemo } from 'react';
 import BigNumber from 'bignumber.js';
 
 import TokenPicker from '../TokenPicker';
-import { Token } from '../../lib/web3/utils/tokens';
+import { Token, roundToBaseUnit } from '../../lib/web3/utils/tokens';
 
 import NumberInput from '../inputs/NumberInput';
 import { useBankBalanceDisplayAmount } from '../../lib/web3/hooks/useUserBankBalances';
 import { useSimplePrice } from '../../lib/tokenPrices';
-import {
-  formatAmount,
-  formatCurrency,
-  formatLongPrice,
-} from '../../lib/utils/number';
+import { formatAmount, formatCurrency } from '../../lib/utils/number';
 
 import './TokenInputGroup.scss';
-
-const { REACT_APP__MAX_FRACTION_DIGITS = '' } = process.env;
-const maxFractionDigits = parseInt(REACT_APP__MAX_FRACTION_DIGITS) || 20;
 
 const placeholder = '0';
 
@@ -95,7 +88,7 @@ export default function TokenInputGroup({
           })}
         </h5>
       )}
-      {!disabledInput && maxValue && Number(maxValue) > 0 && (
+      {!disabledInput && token && maxValue && Number(maxValue) > 0 && (
         <span className="token-group-balance">
           <button
             type="button"
@@ -103,12 +96,7 @@ export default function TokenInputGroup({
             onClick={() =>
               onValueChanged?.(
                 // allow max value be as long as it needs to be to perfectly fit user's balance
-                new BigNumber(maxValue)
-                  .toFixed(maxFractionDigits, BigNumber.ROUND_DOWN)
-                  // replace trailing zeros
-                  .replace(/\.([0-9]*[1-9])?0+$/, '.$1')
-                  // remove trailing decimal point
-                  .replace(/\.$/, '')
+                roundToBaseUnit(token, maxValue) || ''
               )
             }
           >
@@ -119,7 +107,9 @@ export default function TokenInputGroup({
             className="badge badge-light"
             onClick={() =>
               // allow rounding on half of balance because we don't need an exact target
-              onValueChanged?.(formatLongPrice(Number(maxValue) / 2))
+              onValueChanged?.(
+                roundToBaseUnit(token, Number(maxValue) / 2) || ''
+              )
             }
           >
             HALF

--- a/src/components/cards/AssetsTableCard.tsx
+++ b/src/components/cards/AssetsTableCard.tsx
@@ -193,7 +193,6 @@ function AssetRow({
         </div>
         <div className="subtext">
           {`${formatCurrency(value?.toFixed() || '', {
-            useGrouping: true,
             maximumFractionDigits: 6,
           })}`}
         </div>

--- a/src/components/cards/AssetsTableCard.tsx
+++ b/src/components/cards/AssetsTableCard.tsx
@@ -192,7 +192,10 @@ function AssetRow({
           })}`}
         </div>
         <div className="subtext">
-          {`${formatCurrency(value?.toFixed() || '', { maxDecimalPlaces: 6 })}`}
+          {`${formatCurrency(value?.toFixed() || '', {
+            useGrouping: true,
+            maximumFractionDigits: 6,
+          })}`}
         </div>
       </td>
       {showActions && (

--- a/src/components/cards/AssetsTableCard.tsx
+++ b/src/components/cards/AssetsTableCard.tsx
@@ -14,7 +14,7 @@ import { useUserBankValues } from '../../lib/web3/hooks/useUserBankValues';
 import { useFilteredTokenList } from '../../components/TokenPicker/hooks';
 import { dualityChain } from '../../lib/web3/hooks/useChains';
 
-import { formatAmount } from '../../lib/utils/number';
+import { formatAmount, formatCurrency } from '../../lib/utils/number';
 import { Token, getDisplayDenomAmount } from '../../lib/web3/utils/tokens';
 
 import './AssetsTableCard.scss';
@@ -192,9 +192,7 @@ function AssetRow({
           })}`}
         </div>
         <div className="subtext">
-          {`$${formatAmount(value?.toFixed() || '', {
-            useGrouping: true,
-          })}`}
+          {`${formatCurrency(value?.toFixed() || '', { maxDecimalPlaces: 6 })}`}
         </div>
       </td>
       {showActions && (

--- a/src/components/cards/IncentivesCard.tsx
+++ b/src/components/cards/IncentivesCard.tsx
@@ -6,7 +6,7 @@ import TableCard from './TableCard';
 
 import './IncentivesCard.scss';
 import useTokens, { matchTokenByAddress } from '../../lib/web3/hooks/useTokens';
-import { formatAmount, formatDecimalPlaces } from '../../lib/utils/number';
+import { formatAmount } from '../../lib/utils/number';
 
 export default function IncentivesCard({
   className,
@@ -55,12 +55,12 @@ export default function IncentivesCard({
                       Ending{' '}
                       <time>
                         in{' '}
-                        {formatDecimalPlaces(
+                        {formatAmount(
                           Number(gauge.num_epochs_paid_over) -
                             Number(gauge.filled_epochs),
-                          0,
                           {
                             useGrouping: true,
+                            maximumFractionDigits: 0,
                           }
                         )}{' '}
                         Days

--- a/src/components/cards/PoolStakesTableCard.tsx
+++ b/src/components/cards/PoolStakesTableCard.tsx
@@ -24,7 +24,6 @@ import TableCard, { TableCardProps } from './TableCard';
 import {
   formatAmount,
   formatCurrency,
-  formatDecimalPlaces,
   formatPercentage,
 } from '../../lib/utils/number';
 import { Token, getDisplayDenomAmount } from '../../lib/web3/utils/tokens';
@@ -461,7 +460,7 @@ function StakingRow({
           <label className="pt-0 pb-2 pr-3">{checkbox}</label>
         </td>
         <td className="min-width pl-3">
-          {formatDecimalPlaces(
+          {formatAmount(
             tickIndexToPrice(
               !tokensInverted
                 ? new BigNumber(
@@ -471,9 +470,10 @@ function StakingRow({
                     userPosition.deposit.centerTickIndex1To0.toNumber()
                   ).negated()
             ).toFixed(),
-            columnDecimalPlaces.price,
             {
               useGrouping: true,
+              minimumFractionDigits: columnDecimalPlaces.price,
+              maximumFractionDigits: columnDecimalPlaces.price,
             }
           )}{' '}
           <span className="text-muted">

--- a/src/components/cards/PoolStakesTableCard.tsx
+++ b/src/components/cards/PoolStakesTableCard.tsx
@@ -22,6 +22,7 @@ import { Gauge } from '@duality-labs/dualityjs/types/codegen/dualitylabs/duality
 import TableCard, { TableCardProps } from './TableCard';
 
 import {
+  formatAmount,
   formatCurrency,
   formatDecimalPlaces,
   formatPercentage,
@@ -152,10 +153,11 @@ export default function MyPoolStakesTableCard<T extends string | number>({
       if (!value) {
         return 2;
       }
-      return (
-        new BigNumber(value).toPrecision(precision).split('.').pop()?.length ||
-        0
-      );
+      // two steps are required here so that big/small values don't become
+      // scientific notation strings, eg. 1.2e-9
+      const roundedValue = new BigNumber(value).toPrecision(precision);
+      const stringValue = new BigNumber(roundedValue).toFixed();
+      return stringValue.split('.').pop()?.length || 0;
     }
   }, [allShareValues, tokenA, tokenB]);
 
@@ -523,12 +525,14 @@ function StakingRow({
           {tokenAContext?.userReserves.isGreaterThan(0) && (
             <div>
               <span>
-                {formatDecimalPlaces(
+                {formatAmount(
                   getDisplayDenomAmount(
                     tokenA,
-                    tokenAContext?.userReserves || 0
+                    tokenAContext?.userReserves || 0,
+                    {
+                      fractionalDigits: columnDecimalPlaces.amountA,
+                    }
                   ) || 0,
-                  columnDecimalPlaces.amountA,
                   {
                     useGrouping: true,
                   }
@@ -540,12 +544,14 @@ function StakingRow({
           {tokenBContext?.userReserves.isGreaterThan(0) && (
             <div>
               <span>
-                {formatDecimalPlaces(
+                {formatAmount(
                   getDisplayDenomAmount(
                     tokenB,
-                    tokenBContext?.userReserves || 0
+                    tokenBContext?.userReserves || 0,
+                    {
+                      fractionalDigits: columnDecimalPlaces.amountB,
+                    }
                   ) || 0,
-                  columnDecimalPlaces.amountB,
                   {
                     useGrouping: true,
                   }

--- a/src/components/cards/PoolStakesTableCard.tsx
+++ b/src/components/cards/PoolStakesTableCard.tsx
@@ -501,7 +501,7 @@ function StakingRow({
             minimumFractionDigits: 2,
           })}
         </td>
-        <td>{formatCurrency(tokenAValue.plus(tokenBValue).toFixed(2))}</td>
+        <td>{formatCurrency(tokenAValue.plus(tokenBValue).toNumber())}</td>
         <td className="min-width">
           <div
             className={[

--- a/src/components/cards/PoolsTableCard.tsx
+++ b/src/components/cards/PoolsTableCard.tsx
@@ -13,7 +13,7 @@ import useTokens, {
   useTokensWithIbcInfo,
 } from '../../lib/web3/hooks/useTokens';
 
-import { formatAmount } from '../../lib/utils/number';
+import { formatAmount, formatCurrency } from '../../lib/utils/number';
 import { Token, getDisplayDenomAmount } from '../../lib/web3/utils/tokens';
 import useTokenPairs from '../../lib/web3/hooks/useTokenPairs';
 import { useTokenPairTickLiquidity } from '../../lib/web3/hooks/useTickLiquidity';
@@ -215,7 +215,7 @@ function PairRow({
           )}
         </td>
         {/* TVL col */}
-        <td>{value0 && value1 && <>${value0.plus(value1).toFixed(2)}</>}</td>
+        <td>{formatCurrency(value0.plus(value1).toNumber())}</td>
         {/* Volume (7 days) col */}
         <td>-</td>
         {/* Volatility (7 days) col */}
@@ -416,7 +416,7 @@ function PositionRow({
         <td>
           <TokenPair token0={token0} token1={token1} onClick={onClick} />
         </td>
-        <td>{value0 && value1 && <>${value0.plus(value1).toFixed(2)}</>}</td>
+        <td>{formatCurrency(value0.plus(value1).toNumber())}</td>
         <td>
           <span className="token-compositions">
             {formatAmount(getDisplayDenomAmount(token0, total0) || 0)}

--- a/src/lib/utils/number.ts
+++ b/src/lib/utils/number.ts
@@ -142,27 +142,26 @@ export function formatLongPrice(
 export function formatCurrency(
   amount: number | string,
   {
-    currency = 'USD',
-    decimalPlaces = 2,
-    maxDecimalPlaces = decimalPlaces,
-  }: {
-    currency?: string;
-    decimalPlaces?: number;
-    maxDecimalPlaces?: number;
-  } = {}
+    minimumFractionDigits = 2,
+    maximumFractionDigits = minimumFractionDigits,
+    ...numberFormatOptions
+  }: Intl.NumberFormatOptions = {}
 ) {
   const numericAmount = Number(amount);
-  const minimumDisplayedCurrencyValue = Math.pow(10, -1 * maxDecimalPlaces);
+  const minimumDisplayedCurrencyValue = Math.pow(10, -maximumFractionDigits);
   const isLessThanMinimum =
     numericAmount > 0 && numericAmount < minimumDisplayedCurrencyValue;
   const stringAmount = (
     isLessThanMinimum ? minimumDisplayedCurrencyValue : numericAmount
   ).toLocaleString('en-US', {
-    currency,
-    minimumFractionDigits: decimalPlaces,
-    maximumFractionDigits: maxDecimalPlaces,
+    // add defaults
+    currency: 'USD',
     currencyDisplay: 'symbol',
     style: 'currency',
+    // add user given options
+    minimumFractionDigits,
+    maximumFractionDigits,
+    ...numberFormatOptions,
   });
   // add "less than" indicator for small (non-zero) amounts
   return `${isLessThanMinimum ? '<' : ''}${stringAmount}`;

--- a/src/lib/utils/number.ts
+++ b/src/lib/utils/number.ts
@@ -141,19 +141,26 @@ export function formatLongPrice(
 // than its denom exponent (eg. it has come from `getDisplayDenomAmount()`)
 export function formatCurrency(
   amount: number | string,
-  currency = 'USD',
-  decimalPlaces = 2
+  {
+    currency = 'USD',
+    decimalPlaces = 2,
+    maxDecimalPlaces = decimalPlaces,
+  }: {
+    currency?: string;
+    decimalPlaces?: number;
+    maxDecimalPlaces?: number;
+  } = {}
 ) {
   const numericAmount = Number(amount);
-  const minimumDisplayedCurrencyValue = Math.pow(10, -1 * decimalPlaces);
+  const minimumDisplayedCurrencyValue = Math.pow(10, -1 * maxDecimalPlaces);
   const isLessThanMinimum =
-    numericAmount > 0 && numericAmount < minimumDisplayedCurrencyValue / 2;
+    numericAmount > 0 && numericAmount < minimumDisplayedCurrencyValue;
   const stringAmount = (
     isLessThanMinimum ? minimumDisplayedCurrencyValue : numericAmount
   ).toLocaleString('en-US', {
     currency,
     minimumFractionDigits: decimalPlaces,
-    maximumFractionDigits: decimalPlaces,
+    maximumFractionDigits: maxDecimalPlaces,
     currencyDisplay: 'symbol',
     style: 'currency',
   });

--- a/src/lib/utils/number.ts
+++ b/src/lib/utils/number.ts
@@ -152,7 +152,11 @@ export function formatCurrency(
   const isLessThanMinimum =
     numericAmount > 0 && numericAmount < minimumDisplayedCurrencyValue;
   const stringAmount = (
-    isLessThanMinimum ? minimumDisplayedCurrencyValue : numericAmount
+    isLessThanMinimum
+      ? minimumDisplayedCurrencyValue
+      : isNaN(numericAmount)
+      ? numericAmount
+      : '-'
   ).toLocaleString('en-US', {
     // add defaults
     currency: 'USD',

--- a/src/lib/utils/number.ts
+++ b/src/lib/utils/number.ts
@@ -139,6 +139,7 @@ export function formatCurrency(
     currency: 'USD',
     currencyDisplay: 'symbol',
     style: 'currency',
+    useGrouping: true,
     // add user given options
     minimumFractionDigits,
     maximumFractionDigits,

--- a/src/lib/utils/number.ts
+++ b/src/lib/utils/number.ts
@@ -119,7 +119,10 @@ export function formatLongPrice(
   amount: number | string,
   opts: Intl.NumberFormatOptions = {}
 ) {
-  return formatPrice(amount, { maximumSignificantDigits: 6, ...opts });
+  return formatPrice(amount, {
+    maximumSignificantDigits: 6,
+    ...opts,
+  });
 }
 
 // format to a visually pleasing output of currency eg. $1,234.00 / <$0.01 / $0

--- a/src/lib/utils/number.ts
+++ b/src/lib/utils/number.ts
@@ -64,12 +64,14 @@ export function formatAmount(
     // avoid rendering very long fractional values with a practical limit
     maximumFractionDigits = minimumFractionDigits ?? 6,
     ...numberFormatOptions
-  }: Intl.NumberFormatOptions = {}
+  }: Intl.NumberFormatOptions = {},
+  { reformatSmallValues = true } = {}
 ) {
   const numericAmount = Number(amount);
   // use passed limits to determine when we show a small value (eg. <0.001)
   const minimumValue = Math.pow(10, -maximumFractionDigits);
-  const isSmallValue = numericAmount > 0 && numericAmount < minimumValue;
+  const isSmallValue =
+    reformatSmallValues && numericAmount > 0 && numericAmount < minimumValue;
   const stringAmount = (
     isSmallValue ? minimumValue : !isNaN(numericAmount) ? numericAmount : '-'
   ).toLocaleString('en-US', {

--- a/src/lib/utils/number.ts
+++ b/src/lib/utils/number.ts
@@ -102,7 +102,7 @@ export function formatDecimalPlaces(
 export function formatPercentage(
   amount: number | string,
   opts: Intl.NumberFormatOptions = {},
-  maximumSignificantDecimals = 3
+  maximumSignificantDecimals = opts.maximumSignificantDigits ?? 3
 ) {
   const percentage = Number(amount) * 100;
   const roundedAmount = formatMaximumSignificantDecimals(

--- a/src/lib/utils/number.ts
+++ b/src/lib/utils/number.ts
@@ -86,21 +86,6 @@ export function formatAmount(
   return `${isSmallValue ? '<' : ''}${stringAmount}`;
 }
 
-export function formatDecimalPlaces(
-  amount: number | string,
-  fractionDigits = 2,
-  opts: Intl.NumberFormatOptions = {}
-) {
-  const numericAmount = Number(amount);
-  return !isNaN(numericAmount)
-    ? numericAmount.toLocaleString('en-US', {
-        minimumFractionDigits: fractionDigits,
-        maximumFractionDigits: fractionDigits,
-        ...opts,
-      })
-    : '-';
-}
-
 export function formatPercentage(
   amount: number | string,
   opts: Intl.NumberFormatOptions = {},

--- a/src/lib/utils/number.ts
+++ b/src/lib/utils/number.ts
@@ -60,9 +60,9 @@ export function formatMaximumSignificantDecimals(
 export function formatAmount(
   amount: number | string,
   {
-    minimumFractionDigits,
+    minimumFractionDigits = 0,
     // avoid rendering very long fractional values with a practical limit
-    maximumFractionDigits = minimumFractionDigits ?? 6,
+    maximumFractionDigits = Math.max(minimumFractionDigits, 6),
     ...numberFormatOptions
   }: Intl.NumberFormatOptions = {},
   { reformatSmallValues = true } = {}

--- a/src/lib/utils/number.ts
+++ b/src/lib/utils/number.ts
@@ -98,7 +98,7 @@ export function formatPercentage(
   );
   const numericAmount = Number(roundedAmount);
   return !isNaN(numericAmount)
-    ? `${numericAmount.toLocaleString('en-US', {
+    ? `${formatAmount(numericAmount, {
         useGrouping: true,
         ...opts,
       })}%`

--- a/src/lib/web3/utils/tokens.ts
+++ b/src/lib/web3/utils/tokens.ts
@@ -39,7 +39,7 @@ export function getDenomAmount(
     .sort((a, b) => a.exponent - b.exponent)[0].denom,
   {
     fractionalDigits,
-    // so digits forcibly past fractional digits
+    // set minimum significant digits forcibly past fractional digits
     significantDigits,
   }: {
     fractionalDigits?: number;

--- a/src/lib/web3/utils/tokens.ts
+++ b/src/lib/web3/utils/tokens.ts
@@ -108,6 +108,19 @@ export function getBaseDenomAmount(
   });
 }
 
+export function roundToBaseUnit(
+  token: Token,
+  amount: BigNumber.Value,
+  roundingMode: BigNumber.RoundingMode = BigNumber.ROUND_DOWN
+): string | undefined {
+  const baseAmount = getBaseDenomAmount(token, amount);
+  const roundedAmount =
+    baseAmount && new BigNumber(baseAmount).toFixed(0, roundingMode);
+  const displayAmount =
+    roundedAmount && getDisplayDenomAmount(token, roundedAmount);
+  return displayAmount && new BigNumber(displayAmount).toFixed();
+}
+
 // get how much a utoken amount is worth in USD
 export function getTokenValue(
   token: Token,

--- a/src/pages/Pool/MyPositionTableCard.tsx
+++ b/src/pages/Pool/MyPositionTableCard.tsx
@@ -184,9 +184,7 @@ export function MyNewPositionTableCard({
         data ? (
           <>
             <span className="text-muted">Total Assets</span>
-            <strong>
-              {valueTotal ? formatCurrency(valueTotal.toFixed()) : '...'}
-            </strong>
+            <strong>{valueTotal ? formatCurrency(valueTotal) : '...'}</strong>
           </>
         ) : null
       }
@@ -428,9 +426,7 @@ export function MyEditedPositionTableCard({
       header={
         <>
           <span className="text-muted">Total Assets</span>
-          <strong>
-            {valueTotal ? formatCurrency(valueTotal.toFixed()) : '...'}
-          </strong>
+          <strong>{valueTotal ? formatCurrency(valueTotal) : '...'}</strong>
         </>
       }
       data={data}

--- a/src/pages/Pool/MyPositionTableCard.tsx
+++ b/src/pages/Pool/MyPositionTableCard.tsx
@@ -120,7 +120,9 @@ export function MyNewPositionTableCard({
           return (
             <tr key={index} className="pt-2">
               <td>{index + 1}</td>
-              <td>{new BigNumber(priceBToA.toFixed(5)).toFixed(5)}</td>
+              <td>
+                {priceBToA ? formatAmount(priceBToA.toNumber(), {}, 0) : '-'}
+              </td>
               <td>
                 {reserveA.isGreaterThan(0) && (
                   <div>{formatCurrency(poolValues[index][0])}</div>
@@ -300,7 +302,7 @@ export function MyEditedPositionTableCard({
             ? new BigNumber(deposit.centerTickIndex1To0.toNumber())
             : new BigNumber(deposit.centerTickIndex1To0.toNumber()).negated();
 
-          const priceBToA = tickIndexToPrice(tickIndexBToA.negated());
+          const priceBToA = tickIndexToPrice(tickIndexBToA);
           // show only those ticks that are in the currently visible range
           return viewableMinIndex !== undefined &&
             viewableMaxIndex !== undefined &&
@@ -308,7 +310,9 @@ export function MyEditedPositionTableCard({
             tickIndexBToA.isLessThanOrEqualTo(viewableMaxIndex) ? (
             <tr key={index} className="pt-2">
               <td>{index + 1}</td>
-              <td>{new BigNumber(1).div(priceBToA).toFixed(5)}</td>
+              <td>
+                {priceBToA ? formatAmount(priceBToA.toNumber(), {}, 0) : '-'}
+              </td>
               <td>
                 {reserveA.isGreaterThan(0) && (
                   <div>{formatCurrency(poolValues[index][0])}</div>

--- a/src/pages/Pool/MyPositionTableCard.tsx
+++ b/src/pages/Pool/MyPositionTableCard.tsx
@@ -2,7 +2,7 @@ import { ReactNode, useMemo } from 'react';
 import BigNumber from 'bignumber.js';
 import { Tick } from '../../components/LiquiditySelector/LiquiditySelector';
 
-import { formatCurrency } from '../../lib/utils/number';
+import { formatAmount, formatCurrency } from '../../lib/utils/number';
 import { tickIndexToPrice } from '../../lib/web3/utils/ticks';
 import { Token, getDisplayDenomAmount } from '../../lib/web3/utils/tokens';
 
@@ -442,14 +442,6 @@ export function MyEditedPositionTableCard({
   );
 }
 
-function formatReserveAmount(
-  token: Token,
-  reserve: BigNumber,
-  fractionalDigits = 3
-) {
-  return reserve.isGreaterThan(1e-5)
-    ? getDisplayDenomAmount(token, reserve, {
-        fractionalDigits,
-      })
-    : '';
+function formatReserveAmount(token: Token, reserve: BigNumber) {
+  return formatAmount(getDisplayDenomAmount(token, reserve) || 0);
 }

--- a/src/pages/Pool/MyPositionTableCard.tsx
+++ b/src/pages/Pool/MyPositionTableCard.tsx
@@ -120,9 +120,7 @@ export function MyNewPositionTableCard({
           return (
             <tr key={index} className="pt-2">
               <td>{index + 1}</td>
-              <td>
-                {priceBToA ? formatAmount(priceBToA.toNumber(), {}, 0) : '-'}
-              </td>
+              <td>{priceBToA ? formatAmount(priceBToA.toNumber()) : '-'}</td>
               <td>
                 {reserveA.isGreaterThan(0) && (
                   <div>{formatCurrency(poolValues[index][0])}</div>
@@ -308,9 +306,7 @@ export function MyEditedPositionTableCard({
             tickIndexBToA.isLessThanOrEqualTo(viewableMaxIndex) ? (
             <tr key={index} className="pt-2">
               <td>{index + 1}</td>
-              <td>
-                {priceBToA ? formatAmount(priceBToA.toNumber(), {}, 0) : '-'}
-              </td>
+              <td>{priceBToA ? formatAmount(priceBToA.toNumber()) : '-'}</td>
               <td>
                 {reserveA.isGreaterThan(0) && (
                   <div>{formatCurrency(poolValues[index][0])}</div>

--- a/src/pages/Pool/PoolManagement.tsx
+++ b/src/pages/Pool/PoolManagement.tsx
@@ -54,6 +54,7 @@ import {
   Token,
   getBaseDenomAmount,
   getDisplayDenomAmount,
+  roundToBaseUnit,
 } from '../../lib/web3/utils/tokens';
 
 import './Pool.scss';
@@ -695,23 +696,28 @@ export default function PoolManagement({
   useLayoutEffect(() => {
     if (tokenA && tokenB && feeType) {
       if (lastUsedInput === 'A') {
+        const amountB = shapeReservesArray
+          .reduce((acc, [, , reserveB]) => acc.plus(reserveB), new BigNumber(0))
+          .toFixed();
         // convert back to display units
-        const amountB = getDisplayDenomAmount(
-          tokenB,
-          shapeReservesArray.reduce((acc, [tickInddex, reserveA, reserveB]) => {
-            return acc.plus(reserveB);
-          }, new BigNumber(0))
+        setInputValueB(
+          roundToBaseUnit(
+            tokenB,
+            getDisplayDenomAmount(tokenB, amountB) || 0
+          ) ?? ''
         );
-        setInputValueB(amountB ? formatAmount(amountB) : '');
       } else if (lastUsedInput === 'B') {
-        // convert back to display units
-        const amountA = getDisplayDenomAmount(
-          tokenA,
-          shapeReservesArray.reduce((acc, [tickInddex, reserveA, reserveB]) => {
-            return acc.plus(reserveA);
-          }, new BigNumber(0))
+        const amountA = shapeReservesArray.reduce(
+          (acc, [, reserveA]) => acc.plus(reserveA),
+          new BigNumber(0)
         );
-        setInputValueA(amountA ? formatAmount(amountA) : '');
+        // convert back to display units
+        setInputValueA(
+          roundToBaseUnit(
+            tokenA,
+            getDisplayDenomAmount(tokenA, amountA) || 0
+          ) ?? ''
+        );
       }
       // if either side is set then calculate the new user ticks
       if (lastUsedInput) {

--- a/src/pages/Pool/PoolManagement.tsx
+++ b/src/pages/Pool/PoolManagement.tsx
@@ -702,7 +702,10 @@ export default function PoolManagement({
         // convert to the display units of the original token
         const displayAmountB = getDisplayDenomAmount(tokenB, amountB);
         // then transpose this complementary value to the new units
-        setInputValueB(roundToBaseUnit(tokenB, displayAmountB || 0) ?? '');
+        setInputValueB(
+          roundToBaseUnit(tokenB, new BigNumber(displayAmountB || 0).sd(6)) ??
+            ''
+        );
       } else if (lastUsedInput === 'B') {
         const amountA = shapeReservesArray.reduce(
           (acc, [, reserveA]) => acc.plus(reserveA),
@@ -711,7 +714,10 @@ export default function PoolManagement({
         // convert to the display units of the original token
         const displayAmountA = getDisplayDenomAmount(tokenA, amountA);
         // then transpose this complementary value to the new units
-        setInputValueA(roundToBaseUnit(tokenA, displayAmountA || 0) ?? '');
+        setInputValueA(
+          roundToBaseUnit(tokenA, new BigNumber(displayAmountA || 0).sd(6)) ??
+            ''
+        );
       }
       // if either side is set then calculate the new user ticks
       if (lastUsedInput) {
@@ -1323,7 +1329,9 @@ export default function PoolManagement({
                       <div className="row gap-2">
                         <strong>Current Price:</strong>
                         <div className="chart-highlight">
-                          {currentPriceFromTicks?.toFixed(5) ?? '-'}
+                          {currentPriceFromTicks !== undefined
+                            ? formatAmount(currentPriceFromTicks.toFixed() || 0)
+                            : '-'}
                         </div>
                         {tokenA && tokenB && (
                           <div>

--- a/src/pages/Pool/PoolManagement.tsx
+++ b/src/pages/Pool/PoolManagement.tsx
@@ -699,25 +699,19 @@ export default function PoolManagement({
         const amountB = shapeReservesArray
           .reduce((acc, [, , reserveB]) => acc.plus(reserveB), new BigNumber(0))
           .toFixed();
-        // convert back to display units
-        setInputValueB(
-          roundToBaseUnit(
-            tokenB,
-            getDisplayDenomAmount(tokenB, amountB) || 0
-          ) ?? ''
-        );
+        // convert to the display units of the original token
+        const displayAmountB = getDisplayDenomAmount(tokenB, amountB);
+        // then transpose this complementary value to the new units
+        setInputValueB(roundToBaseUnit(tokenB, displayAmountB || 0) ?? '');
       } else if (lastUsedInput === 'B') {
         const amountA = shapeReservesArray.reduce(
           (acc, [, reserveA]) => acc.plus(reserveA),
           new BigNumber(0)
         );
-        // convert back to display units
-        setInputValueA(
-          roundToBaseUnit(
-            tokenA,
-            getDisplayDenomAmount(tokenA, amountA) || 0
-          ) ?? ''
-        );
+        // convert to the display units of the original token
+        const displayAmountA = getDisplayDenomAmount(tokenA, amountA);
+        // then transpose this complementary value to the new units
+        setInputValueA(roundToBaseUnit(tokenA, displayAmountA || 0) ?? '');
       }
       // if either side is set then calculate the new user ticks
       if (lastUsedInput) {

--- a/src/pages/Pool/PoolManagement.tsx
+++ b/src/pages/Pool/PoolManagement.tsx
@@ -96,7 +96,8 @@ const defaultPrecision = '30';
 const formatRangeString = (value: BigNumber.Value, significantDecimals = 3) => {
   return formatAmount(
     formatMaximumSignificantDecimals(value, significantDecimals),
-    { minimumSignificantDigits: significantDecimals }
+    { minimumSignificantDigits: significantDecimals },
+    { reformatSmallValues: false }
   );
 };
 

--- a/src/pages/Pool/PoolOverview.tsx
+++ b/src/pages/Pool/PoolOverview.tsx
@@ -849,12 +849,9 @@ function SwapColumn({
             getDisplayDenomAmount(tokenB, getTokenBReserves()) || 0
           ).multipliedBy(tokenBPrice || 0),
         ];
-        const value = values[0].plus(values[1]);
         // return loading start or calculated value
         return !tokenA && !tokenB && isValidating
           ? '...'
-          : value.isLessThan(0.005)
-          ? `< ${formatCurrency(0.01)}`
           : formatCurrency(values[0].plus(values[1]).toNumber());
       case 'Time':
         return tx.timestamp

--- a/src/pages/Pool/PoolOverview.tsx
+++ b/src/pages/Pool/PoolOverview.tsx
@@ -283,10 +283,7 @@ function Incentives({ tokenA, tokenB }: { tokenA?: Token; tokenB?: Token }) {
                         tickIndexToPrice(
                           new BigNumber(`${row.distribute_to.endTick}`) || 0
                         ).toNumber(),
-                        {
-                          useGrouping: true,
-                          minimumSignificantDigits: 2,
-                        }
+                        { useGrouping: true, minimumSignificantDigits: 2 }
                       )}
                     </div>
                     <div className="col text-muted">

--- a/src/pages/Pool/PoolOverview.tsx
+++ b/src/pages/Pool/PoolOverview.tsx
@@ -691,9 +691,13 @@ function EventColumn<
           .filter(Boolean)
           .join(' and ')}`;
       case 'Token A Amount':
-        return getTokenReservesInDenom(tokenA, getTokenAReserves().toFixed());
+        return formatAmount(
+          getTokenReservesInDenom(tokenA, getTokenAReserves().toFixed()) || 0
+        );
       case 'Token B Amount':
-        return getTokenReservesInDenom(tokenB, getTokenBReserves().toFixed());
+        return formatAmount(
+          getTokenReservesInDenom(tokenB, getTokenBReserves().toFixed()) || 0
+        );
       case 'Total Value':
         const values = [
           new BigNumber(
@@ -703,12 +707,9 @@ function EventColumn<
             getDisplayDenomAmount(tokenB, getTokenBReserves()) || 0
           ).multipliedBy(tokenBPrice || 0),
         ];
-        const value = values[0].plus(values[1]);
         // return loading start or calculated value
         return !tokenA && !tokenB && isValidating
           ? '...'
-          : value.isLessThan(0.005)
-          ? `< ${formatCurrency(0.01)}`
           : formatCurrency(values[0].plus(values[1]).toNumber());
       case 'Time':
         return tx.timestamp

--- a/src/pages/Pool/PoolOverview.tsx
+++ b/src/pages/Pool/PoolOverview.tsx
@@ -833,9 +833,13 @@ function SwapColumn({
           .filter(Boolean)
           .join(' and ')}`;
       case 'Token A Amount':
-        return getTokenReservesInDenom(tokenA, getTokenAReserves());
+        return formatAmount(
+          getTokenReservesInDenom(tokenA, getTokenAReserves()) || '0'
+        );
       case 'Token B Amount':
-        return getTokenReservesInDenom(tokenB, getTokenBReserves());
+        return formatAmount(
+          getTokenReservesInDenom(tokenB, getTokenBReserves()) || '0'
+        );
       case 'Total Value':
         const values = [
           new BigNumber(

--- a/src/pages/Swap/Swap.tsx
+++ b/src/pages/Swap/Swap.tsx
@@ -30,7 +30,7 @@ import { useTokenPairTickLiquidity } from '../../lib/web3/hooks/useTickLiquidity
 import { getRouterEstimates, useRouterResult } from './hooks/useRouter';
 import { useSwap } from './hooks/useSwap';
 
-import { formatAmount } from '../../lib/utils/number';
+import { formatPercentage } from '../../lib/utils/number';
 import { Token, getBaseDenomAmount } from '../../lib/web3/utils/tokens';
 import { formatLongPrice } from '../../lib/utils/number';
 
@@ -322,10 +322,10 @@ function Swap() {
     routerResult.priceBToAIn?.isGreaterThan(0) &&
     routerResult.priceBToAOut?.isGreaterThan(0)
       ? new BigNumber(
-          new BigNumber(routerResult.priceBToAIn)
-            .dividedBy(new BigNumber(routerResult.priceBToAOut))
-            .multipliedBy(100)
-        ).minus(100)
+          new BigNumber(routerResult.priceBToAIn).dividedBy(
+            new BigNumber(routerResult.priceBToAOut)
+          )
+        ).minus(1)
       : undefined;
 
   const tradeCard = (
@@ -466,9 +466,9 @@ function Swap() {
                         switch (true) {
                           case priceImpact.isGreaterThanOrEqualTo(0):
                             return 'text-success';
-                          case priceImpact.isGreaterThan(-1):
+                          case priceImpact.isGreaterThan(-0.01):
                             return 'text-value';
-                          case priceImpact.isGreaterThan(-5):
+                          case priceImpact.isGreaterThan(-0.05):
                             return 'text';
                           default:
                             return 'text-error';
@@ -476,11 +476,10 @@ function Swap() {
                       })(),
                     ].join(' ')}
                   >
-                    {formatAmount(priceImpact.toFixed(), {
+                    {formatPercentage(priceImpact.toFixed(), {
                       maximumSignificantDigits: 4,
                       minimumSignificantDigits: 4,
                     })}
-                    %
                   </span>
                 )}
               </div>

--- a/src/pages/Swap/hooks/useRouter.ts
+++ b/src/pages/Swap/hooks/useRouter.ts
@@ -1,7 +1,7 @@
 import { useEffect, useState } from 'react';
 import { PairRequest, PairResult, RouterResult } from './index';
 import { routerAsync, calculateFee, SwapError } from './router';
-import { formatAmount } from '../../../lib/utils/number';
+import { formatMaximumSignificantDecimals } from '../../../lib/utils/number';
 
 import BigNumber from 'bignumber.js';
 import {
@@ -192,8 +192,8 @@ export function getRouterEstimates(
         tokenA: routerResult.tokenIn,
         tokenB: routerResult.tokenOut,
         rate: rate.toFixed(),
-        valueA: formatAmount(routerResult.amountIn.toFixed()),
-        valueB: formatAmount(routerResult.amountOut.toFixed()),
+        valueA: formatMaximumSignificantDecimals(routerResult.amountIn),
+        valueB: formatMaximumSignificantDecimals(routerResult.amountOut),
         gas: extraFee.toFixed(),
       };
       cachedRequests[token0] = cachedRequests[token0] || {};
@@ -218,13 +218,13 @@ export function getRouterEstimates(
           pairRequest.tokenA === cachedPairInfo.tokenA
             ? new BigNumber(rate)
             : new BigNumber(1).dividedBy(rate);
-        const roughEstimate = formatAmount(
+        const roughEstimate = formatMaximumSignificantDecimals(
           new BigNumber(alteredValue).multipliedBy(convertedRate).toFixed()
         );
         return {
           tokenA: pairRequest.tokenA,
           tokenB: pairRequest.tokenB,
-          rate: formatAmount(convertedRate.toFixed()),
+          rate: convertedRate.toFixed(),
           valueA: reverseSwap ? roughEstimate : alteredValue,
           valueB: reverseSwap ? alteredValue : roughEstimate,
           gas,


### PR DESCRIPTION
this PR attempts to make formatted numbers in the application more consistent,

and when small values are seen, instead or rendering very small numbers like:
- before
  - `$0.000000000000123456`, we add a default minimum value for different contexts, eg `formatCurrency`:
- after
  - `<$0.01`

Formatting function usage has also been made more consistent

Before:
![localhost_3000_pools_ibc%2F3C3D7B3BE4ECC85A0E5B52A3AEC3B7DFC2AA9CA47C37821E57020D6807043BE9_TKN(FullHD) (1)](https://github.com/duality-labs/duality-web-app/assets/6194521/425dd065-a1a0-494b-8208-059f620afb9d)

After:
![localhost_3000_pools_ibc%2F3C3D7B3BE4ECC85A0E5B52A3AEC3B7DFC2AA9CA47C37821E57020D6807043BE9_TKN(FullHD)](https://github.com/duality-labs/duality-web-app/assets/6194521/a69fb1e0-7050-4d3b-84e3-f066b36e06a5)


Before: 
![localhost_3000_pools_ibc%2F3C3D7B3BE4ECC85A0E5B52A3AEC3B7DFC2AA9CA47C37821E57020D6807043BE9_TKN(FullHD) (2)](https://github.com/duality-labs/duality-web-app/assets/6194521/496720a4-19f0-47bc-8ace-db7ef127ce1c)

After:
![localhost_3000_pools_ibc%2F3C3D7B3BE4ECC85A0E5B52A3AEC3B7DFC2AA9CA47C37821E57020D6807043BE9_TKN(FullHD) (3)](https://github.com/duality-labs/duality-web-app/assets/6194521/c4b80c0b-5bd1-4739-b5a1-4225dea10c4d)
