### PR TITLE
fix: mismatching display denom exponent issues

### DIFF
--- a/src/components/LiquiditySelector/LiquiditySelector.tsx
+++ b/src/components/LiquiditySelector/LiquiditySelector.tsx
@@ -159,6 +159,10 @@ export default function LiquiditySelector({
     [tokenA, tokenB]
   );
 
+  const defaultPriceIndex = useMemo(() => {
+    return shortcutDisplayPriceToTickIndex(new BigNumber(1)).toNumber();
+  }, [shortcutDisplayPriceToTickIndex]);
+
   // convert range price state controls into range index state controls
   const fractionalRangeMinIndex = useMemo(() => {
     const index = shortcutDisplayPriceToTickIndex(
@@ -431,6 +435,7 @@ export default function LiquiditySelector({
   // allow user ticks to reset the boundary of the graph
   const [graphMinIndex, graphMaxIndex] = useMemo<[number, number]>(() => {
     const allValues = [
+      edgePriceIndex ?? defaultPriceIndex,
       ...userTicks.map<number | undefined>((tick) => tick?.tickIndexBToA),
       rangeMinIndex,
       rangeMaxIndex,
@@ -450,6 +455,8 @@ export default function LiquiditySelector({
     }
     return [min, max];
   }, [
+    edgePriceIndex,
+    defaultPriceIndex,
     rangeMinIndex,
     rangeMaxIndex,
     userTicks,
@@ -613,7 +620,7 @@ export default function LiquiditySelector({
     function getReserveBValue(reserve: BigNumber): BigNumber {
       return reserve.multipliedBy(edgePrice);
     }
-  }, [emptyBuckets, tokenATicks, tokenBTicks, edgePriceIndex]);
+  }, [edgePriceIndex, emptyBuckets, tokenATicks, tokenBTicks]);
 
   // calculate highest value to plot on the chart
   const yMaxValue = useMemo(() => {

--- a/src/components/LiquiditySelector/LiquiditySelector.tsx
+++ b/src/components/LiquiditySelector/LiquiditySelector.tsx
@@ -44,7 +44,7 @@ export interface LiquiditySelectorProps {
   fee: number | undefined;
   userTickSelected: number | undefined;
   setUserTickSelected: (index: number) => void;
-  initialPrice?: string;
+  initialPriceIndex?: number;
   rangeMin: string;
   rangeMax: string;
   setRange: React.Dispatch<React.SetStateAction<[string, string]>>;
@@ -127,7 +127,7 @@ export default function LiquiditySelector({
   fee,
   userTickSelected = -1,
   setUserTickSelected,
-  initialPrice = '',
+  initialPriceIndex,
   rangeMin,
   rangeMax,
   setRange,
@@ -252,15 +252,8 @@ export default function LiquiditySelector({
 
   // note edge price, the price of the edge of one-sided liquidity
   const edgePriceIndex = useMemo(() => {
-    if (currentPriceIndexFromTicks !== undefined) {
-      return currentPriceIndexFromTicks;
-    }
-    // return calculated price index
-    if (Number(initialPrice) > 0) {
-      return priceToTickIndex(new BigNumber(initialPrice)).toNumber();
-    }
-    return undefined;
-  }, [currentPriceIndexFromTicks, initialPrice]);
+    return currentPriceIndexFromTicks ?? initialPriceIndex;
+  }, [currentPriceIndexFromTicks, initialPriceIndex]);
 
   // note warning price, the price at which warning states should be shown
   const [tokenAWarningPriceIndex, tokenBWarningPriceIndex] = useMemo(() => {

--- a/src/lib/web3/utils/ticks.ts
+++ b/src/lib/web3/utils/ticks.ts
@@ -1,5 +1,5 @@
 import BigNumber from 'bignumber.js';
-import { Token } from './tokens';
+import { Token, getDisplayDenomAmount } from './tokens';
 
 /**
  * price1To0:
@@ -65,6 +65,19 @@ export interface TickInfo {
 export function tickIndexToPrice(tickIndex: BigNumber): BigNumber {
   return new BigNumber(Math.pow(1.0001, tickIndex.toNumber()));
 }
+export function tickIndexToDisplayPrice(
+  tickIndex: BigNumber,
+  token0: Token | undefined,
+  token1: Token | undefined
+): BigNumber | undefined {
+  const denomMagnitude0 = token0 && getDisplayDenomAmount(token0, 1);
+  const denomMagnitude1 = token1 && getDisplayDenomAmount(token1, 1);
+  return denomMagnitude0 && denomMagnitude1
+    ? tickIndexToPrice(tickIndex)
+        .multipliedBy(denomMagnitude0)
+        .dividedBy(denomMagnitude1)
+    : undefined;
+}
 
 export function priceToTickIndex(
   price: BigNumber,
@@ -75,6 +88,21 @@ export function priceToTickIndex(
   return new BigNumber(
     roundingFunction(Math.log(price.toNumber()) / Math.log(1.0001))
   );
+}
+export function displayPriceToTickIndex(
+  displayPrice: BigNumber,
+  token0: Token | undefined,
+  token1: Token | undefined,
+  roundingMethod = 'none' as 'round' | 'ceil' | 'floor' | 'none'
+): BigNumber | undefined {
+  const denomMagnitude0 = token0 && getDisplayDenomAmount(token0, 1);
+  const denomMagnitude1 = token1 && getDisplayDenomAmount(token1, 1);
+  return denomMagnitude0 && denomMagnitude1
+    ? priceToTickIndex(
+        displayPrice.multipliedBy(denomMagnitude1).dividedBy(denomMagnitude0),
+        roundingMethod
+      )
+    : undefined;
 }
 
 const bigZero = new BigNumber(0);

--- a/src/pages/Pool/MyPositionTableCard.tsx
+++ b/src/pages/Pool/MyPositionTableCard.tsx
@@ -3,7 +3,7 @@ import BigNumber from 'bignumber.js';
 import { Tick } from '../../components/LiquiditySelector/LiquiditySelector';
 
 import { formatAmount, formatCurrency } from '../../lib/utils/number';
-import { tickIndexToPrice } from '../../lib/web3/utils/ticks';
+import { tickIndexToDisplayPrice } from '../../lib/web3/utils/ticks';
 import { Token, getDisplayDenomAmount } from '../../lib/web3/utils/tokens';
 
 import { EditedPosition } from '../MyLiquidity/useEditLiquidity';
@@ -115,12 +115,22 @@ export function MyNewPositionTableCard({
 
   const data =
     tokenA && tokenB && !(reserveATotal.isZero() && reserveBTotal.isZero())
-      ? userTicks.map(({ priceBToA, reserveA, reserveB }, index) => {
+      ? userTicks.map((tick, index) => {
+          const { reserveA, reserveB, tickIndexBToA, tokenA, tokenB } = tick;
+          const displayPriceBToA = tickIndexToDisplayPrice(
+            new BigNumber(tickIndexBToA),
+            tokenA,
+            tokenB
+          );
           // note: fix these restrictions, they are a bit off
           return (
             <tr key={index} className="pt-2">
               <td>{index + 1}</td>
-              <td>{priceBToA ? formatAmount(priceBToA.toNumber()) : '-'}</td>
+              <td>
+                {displayPriceBToA
+                  ? formatAmount(displayPriceBToA.toNumber())
+                  : '-'}
+              </td>
               <td>
                 {reserveA.isGreaterThan(0) && (
                   <div>{formatCurrency(poolValues[index][0])}</div>
@@ -298,7 +308,11 @@ export function MyEditedPositionTableCard({
             ? new BigNumber(deposit.centerTickIndex1To0.toNumber())
             : new BigNumber(deposit.centerTickIndex1To0.toNumber()).negated();
 
-          const priceBToA = tickIndexToPrice(tickIndexBToA);
+          const displayPriceBToA = tickIndexToDisplayPrice(
+            tickIndexBToA,
+            tokenA,
+            tokenB
+          );
           // show only those ticks that are in the currently visible range
           return viewableMinIndex !== undefined &&
             viewableMaxIndex !== undefined &&
@@ -306,7 +320,11 @@ export function MyEditedPositionTableCard({
             tickIndexBToA.isLessThanOrEqualTo(viewableMaxIndex) ? (
             <tr key={index} className="pt-2">
               <td>{index + 1}</td>
-              <td>{priceBToA ? formatAmount(priceBToA.toNumber()) : '-'}</td>
+              <td>
+                {displayPriceBToA
+                  ? formatAmount(displayPriceBToA.toNumber())
+                  : '-'}
+              </td>
               <td>
                 {reserveA.isGreaterThan(0) && (
                   <div>{formatCurrency(poolValues[index][0])}</div>

--- a/src/pages/Pool/PoolManagement.tsx
+++ b/src/pages/Pool/PoolManagement.tsx
@@ -286,8 +286,8 @@ export default function PoolManagement({
         const newPrice = new BigNumber(priceMin);
         return {
           ...tick,
-          reserveA: newReserveA,
-          reserveB: newReserveB,
+          reserveA: newReserveA.decimalPlaces(0),
+          reserveB: newReserveB.decimalPlaces(0),
           priceBToA: new BigNumber(priceMin),
           tickIndexBToA: priceToTickIndex(newPrice).toNumber(),
         };
@@ -296,16 +296,16 @@ export default function PoolManagement({
         const newPrice = new BigNumber(priceMax);
         return {
           ...tick,
-          reserveA: newReserveA,
-          reserveB: newReserveB,
+          reserveA: newReserveA.decimalPlaces(0),
+          reserveB: newReserveB.decimalPlaces(0),
           priceBToA: new BigNumber(priceMax),
           tickIndexBToA: priceToTickIndex(newPrice).toNumber(),
         };
       }
       return {
         ...tick,
-        reserveA: newReserveA,
-        reserveB: newReserveB,
+        reserveA: newReserveA.decimalPlaces(0),
+        reserveB: newReserveB.decimalPlaces(0),
       };
     }
     if (typeof userTicksOrCallback === 'function') {

--- a/src/pages/Pool/PoolManagement.tsx
+++ b/src/pages/Pool/PoolManagement.tsx
@@ -1359,7 +1359,7 @@ export default function PoolManagement({
                     <LiquiditySelector
                       tokenA={tokenA}
                       tokenB={tokenB}
-                      initialPrice={initialPrice}
+                      initialPriceIndex={initialPriceIndex}
                       rangeMin={fractionalRangeMin}
                       rangeMax={fractionalRangeMax}
                       setRange={setRange}

--- a/src/pages/Pool/PoolManagement.tsx
+++ b/src/pages/Pool/PoolManagement.tsx
@@ -615,7 +615,7 @@ export default function PoolManagement({
   > => {
     const amountA = new BigNumber(values[0] || 0);
     const amountB = new BigNumber(values[1] || 0);
-    if (lastUsedInput && edgePriceIndex) {
+    if (lastUsedInput && edgePriceIndex !== undefined) {
       // calculate the used tick indexes
       const tickIndexValues = shapeUnitValueArray.map(
         (value, index, ticks): [tickIndex: number, value: number] => {

--- a/src/pages/Pool/PoolManagement.tsx
+++ b/src/pages/Pool/PoolManagement.tsx
@@ -47,7 +47,12 @@ import {
   formatMaximumSignificantDecimals,
   formatPrice,
 } from '../../lib/utils/number';
-import { priceToTickIndex, tickIndexToPrice } from '../../lib/web3/utils/ticks';
+import {
+  displayPriceToTickIndex,
+  priceToTickIndex,
+  tickIndexToDisplayPrice,
+  tickIndexToPrice,
+} from '../../lib/web3/utils/ticks';
 import { FeeType, feeTypes } from '../../lib/web3/utils/fees';
 import { LiquidityShape, liquidityShapes } from '../../lib/web3/utils/shape';
 import {
@@ -201,9 +206,14 @@ export default function PoolManagement({
   const initialPriceIndex = useMemo(() => {
     const initialPriceNumber = Number(initialPrice);
     return initialPriceNumber > 0
-      ? priceToTickIndex(new BigNumber(initialPriceNumber), 'none')?.toNumber()
+      ? displayPriceToTickIndex(
+          new BigNumber(initialPriceNumber),
+          tokenA,
+          tokenB,
+          'none'
+        )?.toNumber()
       : undefined;
-  }, [initialPrice]);
+  }, [initialPrice, tokenA, tokenB]);
 
   // set edge from ticks or user supplied value
   const edgePriceIndex = useMemo(() => {
@@ -213,9 +223,9 @@ export default function PoolManagement({
   // edge price is the DISPLAY price that the user sees
   const edgePrice = useMemo(() => {
     return edgePriceIndex !== undefined && !isNaN(Number(edgePriceIndex))
-      ? tickIndexToPrice(new BigNumber(edgePriceIndex))
+      ? tickIndexToDisplayPrice(new BigNumber(edgePriceIndex), tokenA, tokenB)
       : undefined;
-  }, [edgePriceIndex]);
+  }, [edgePriceIndex, tokenA, tokenB]);
 
   // reset initial price whenever selected tokens are changed
   useEffect(() => {
@@ -379,20 +389,24 @@ export default function PoolManagement({
   }, [precision]);
 
   const [rangeMinIndex, rangeMaxIndex] = useMemo(() => {
-    const fractionalRangeMinIndex = priceToTickIndex(
+    const fractionalRangeMinIndex = displayPriceToTickIndex(
       new BigNumber(fractionalRangeMin),
+      tokenA,
+      tokenB,
       'none'
-    ).toNumber();
-    const fractionalRangeMaxIndex = priceToTickIndex(
+    )?.toNumber();
+    const fractionalRangeMaxIndex = displayPriceToTickIndex(
       new BigNumber(fractionalRangeMax),
+      tokenA,
+      tokenB,
       'none'
-    ).toNumber();
+    )?.toNumber();
     return getRangeIndexes(
       edgePriceIndex,
-      fractionalRangeMinIndex,
-      fractionalRangeMaxIndex
+      fractionalRangeMinIndex || 0,
+      fractionalRangeMaxIndex || 0
     );
-  }, [fractionalRangeMin, fractionalRangeMax, edgePriceIndex]);
+  }, [fractionalRangeMin, tokenA, tokenB, fractionalRangeMax, edgePriceIndex]);
 
   const formatSignificantDecimalRangeString = useCallback(
     (price: BigNumber.Value) => {
@@ -402,12 +416,26 @@ export default function PoolManagement({
   );
 
   const rangeMin = useMemo<number>(
-    () => tickIndexToPrice(new BigNumber(rangeMinIndex)).toNumber(),
-    [rangeMinIndex]
+    () =>
+      (rangeMinIndex !== undefined &&
+        tickIndexToDisplayPrice(
+          new BigNumber(rangeMinIndex),
+          tokenA,
+          tokenB
+        )?.toNumber()) ||
+      NaN,
+    [rangeMinIndex, tokenA, tokenB]
   );
   const rangeMax = useMemo<number>(
-    () => tickIndexToPrice(new BigNumber(rangeMaxIndex)).toNumber(),
-    [rangeMaxIndex]
+    () =>
+      (rangeMaxIndex !== undefined &&
+        tickIndexToDisplayPrice(
+          new BigNumber(rangeMaxIndex),
+          tokenA,
+          tokenB
+        )?.toNumber()) ||
+      NaN,
+    [rangeMaxIndex, tokenA, tokenB]
   );
 
   const [pairPriceMin, pairPriceMax] = useMemo<[number, number]>(() => {
@@ -614,6 +642,8 @@ export default function PoolManagement({
     return unitValues.map((value) => value / unitValuesTotal);
   }, [tickCount, shapeFunction]);
 
+  // shapeReservesArray describes the desired shape of the reserves as accurately as possible
+  // it does not account for denom rounding or amount limits of any kind
   const shapeReservesArray = useMemo((): Array<
     [tickIndex: number, reservesA: BigNumber, reservesB: BigNumber]
   > => {
@@ -1337,9 +1367,11 @@ export default function PoolManagement({
                           {currentPriceIndexFromTicks !== undefined
                             ? formatAmount(
                                 formatMaximumSignificantDecimals(
-                                  tickIndexToPrice(
-                                    new BigNumber(currentPriceIndexFromTicks)
-                                  )
+                                  tickIndexToDisplayPrice(
+                                    new BigNumber(currentPriceIndexFromTicks),
+                                    tokenA,
+                                    tokenB
+                                  )?.toNumber() || 0
                                 ),
                                 { useGrouping: true },
                                 { reformatSmallValues: false }


### PR DESCRIPTION
When using a pair of unequal display denoms (eg. a token with 6 decimal places like most Cosmos tokens, and a token with 18 decimal places like most wrapped Ethereum tokens) many unexpected off-by-12-orders-of-magnitude values are observed, in particularly the Liquidity Chart does not function very well.

This PR fixes the discrepancies between denoms of different exponents, both usage and display in
- the liquidity chart
- liquidity position table values


Before: note that the current price is incorrect by 12 orders of magnitude as STK has 6 decimals places and TKN has 18.
The position of the chart is also incorrect because it attempts to graph tickIndex 0, which is not a relevant point for this chart.
![localhost_3000_pools_ibc%2F3C3D7B3BE4ECC85A0E5B52A3AEC3B7DFC2AA9CA47C37821E57020D6807043BE9_TKN_add(FullHD) (6)](https://github.com/duality-labs/duality-web-app/assets/6194521/c1f0c2ec-0bae-45ab-9ec7-9933a8f3334c)

After:
![localhost_3000_pools_ibc%2F3C3D7B3BE4ECC85A0E5B52A3AEC3B7DFC2AA9CA47C37821E57020D6807043BE9_TKN_add(FullHD) (5)](https://github.com/duality-labs/duality-web-app/assets/6194521/ab280659-5960-41c0-901e-2bb8294be9e9)
