### PR TITLE
fix: better token value calculations for tables

### DIFF
--- a/src/components/Table/ValueBar.scss
+++ b/src/components/Table/ValueBar.scss
@@ -1,0 +1,23 @@
+.value-bar {
+  & {
+    height: 1rem;
+  }
+  &.value-bar--red {
+    background-color: hsl(0deg, 50%, 37%);
+    &.highlighted {
+      background-color: hsl(0, 77%, 61%);
+    }
+  }
+  &.value-bar--green {
+    background-color: hsl(182, 50%, 37%);
+    &.highlighted {
+      background-color: hsl(182, 77%, 61%);
+    }
+  }
+  &.value-bar--blue {
+    background-color: hsl(202, 50%, 37%);
+    &.highlighted {
+      background-color: hsl(202, 77%, 61%);
+    }
+  }
+}

--- a/src/components/Table/ValueBar.tsx
+++ b/src/components/Table/ValueBar.tsx
@@ -1,0 +1,29 @@
+import BigNumber from 'bignumber.js';
+
+import './ValueBar.scss';
+
+export default function ValueBar({
+  className,
+  variant,
+  width = 50,
+  value = 0,
+  maxValue = 0,
+}: {
+  className?: string | false;
+  width?: number;
+  variant: 'green' | 'blue' | 'red';
+  value: BigNumber.Value | undefined;
+  maxValue: BigNumber.Value | undefined;
+}) {
+  const percent = new BigNumber(value).dividedBy(maxValue).toNumber();
+  return (
+    <div
+      className={['value-bar', `value-bar--${variant}`, className]
+        .filter(Boolean)
+        .join(' ')}
+      style={{
+        width: percent * width || 0,
+      }}
+    ></div>
+  );
+}

--- a/src/components/cards/PoolStakesTableCard.tsx
+++ b/src/components/cards/PoolStakesTableCard.tsx
@@ -38,6 +38,7 @@ import IncentivesCard from './IncentivesCard';
 import { tickIndexToPrice } from '../../lib/web3/utils/ticks';
 import { guessInvertedOrder } from '../../lib/web3/utils/pairs';
 import { matchTokens } from '../../lib/web3/hooks/useTokens';
+import { useCurrentPriceFromTicks } from '../LiquiditySelector/useCurrentPriceFromTicks';
 
 import './PoolsTableCard.scss';
 import { useStake } from '../../pages/MyLiquidity/useStaking';
@@ -76,16 +77,29 @@ export default function MyPoolStakesTableCard<T extends string | number>({
     return [...userPositionsShareValues, ...userStakedShareValues];
   }, [userPositionsShareValues, userStakedShareValues]);
 
-  const maxPoolValue = useMemo(() => {
-    return allShareValues.reduce<number>(
-      (acc, { token0Value, token1Value }) => {
-        const value =
-          (token0Value?.toNumber() || 0) + (token1Value?.toNumber() || 0);
-        return value > acc ? value : acc;
-      },
-      0
-    );
-  }, [allShareValues]);
+  const edgePrice = useCurrentPriceFromTicks(tokenA.address, tokenB.address);
+
+  const maxPoolEquivalentReservesA = useMemo(() => {
+    return edgePrice
+      ? allShareValues.reduce<number>(
+          (acc, { token0, token0Context, token1Context }, index) => {
+            const forward = matchTokens(token0, tokenA);
+            const reverse = matchTokens(token0, tokenB);
+            const tokenAContext = forward ? token0Context : token1Context;
+            const tokenBContext = reverse ? token0Context : token1Context;
+            const tokenAValue = tokenAContext?.userReserves;
+            const tokenBValue =
+              tokenBContext?.userReserves.multipliedBy(edgePrice);
+            return Math.max(
+              acc,
+              tokenAValue?.toNumber() || 0,
+              tokenBValue?.toNumber() || 0
+            );
+          },
+          0
+        )
+      : 0;
+  }, [allShareValues, edgePrice, tokenA, tokenB]);
 
   const columnDecimalPlaces = useMemo(() => {
     const values = allShareValues.reduce<{
@@ -353,7 +367,7 @@ export default function MyPoolStakesTableCard<T extends string | number>({
                     tokenA={tokenA}
                     tokenB={tokenB}
                     userPosition={userPosition}
-                    maxPoolValue={maxPoolValue}
+                    maxPoolEquivalentReservesA={maxPoolEquivalentReservesA}
                     columnDecimalPlaces={columnDecimalPlaces}
                     checkbox={checkbox}
                   />
@@ -410,14 +424,14 @@ function StakingRow({
   tokenA,
   tokenB,
   userPosition,
-  maxPoolValue = 1,
+  maxPoolEquivalentReservesA = 0,
   columnDecimalPlaces,
   checkbox,
 }: {
   tokenA: Token;
   tokenB: Token;
   userPosition: ValuedUserPositionDepositContext;
-  maxPoolValue: number;
+  maxPoolEquivalentReservesA: number;
   columnDecimalPlaces: {
     price: number;
     fee: number;
@@ -429,6 +443,7 @@ function StakingRow({
 }) {
   const tokensInverted = !matchTokens(tokenA, userPosition.token0);
 
+  const edgePrice = useCurrentPriceFromTicks(tokenA.address, tokenB.address);
   const {
     tokenAContext,
     tokenBContext,
@@ -453,7 +468,11 @@ function StakingRow({
   const isStaked = userPosition.stakeContext;
   const isIncentivized = !!incentives && incentives?.length > 0;
 
-  if (tokenAValue.isGreaterThan(0) || tokenBValue.isGreaterThan(0)) {
+  if (
+    edgePrice &&
+    maxPoolEquivalentReservesA &&
+    (tokenAContext || tokenBContext)
+  ) {
     return (
       <tr>
         <td className="min-width">
@@ -502,22 +521,27 @@ function StakingRow({
             minimumFractionDigits: 2,
           })}
         </td>
+        {/* this shows the USD equivalent value of the user's token reserves */}
         <td>{formatCurrency(tokenAValue.plus(tokenBValue).toNumber())}</td>
+        {/*
+         * this shows the reserveA equivalent value of the token reserves
+         * (not USD equivalent) because there may not be a USD price
+         */}
         <td className="min-width">
-          {tokenAValue.isGreaterThan(0) && (
+          {tokenAContext?.userReserves.isGreaterThan(0) && (
             <ValueBar
               className={isStaked && isIncentivized && 'highlighted'}
               variant="green"
-              value={tokenAValue}
-              maxValue={maxPoolValue}
+              value={tokenAContext?.userReserves}
+              maxValue={maxPoolEquivalentReservesA}
             />
           )}
-          {tokenBValue.isGreaterThan(0) && (
+          {tokenBContext?.userReserves.isGreaterThan(0) && (
             <ValueBar
               className={isStaked && isIncentivized && 'highlighted'}
               variant="blue"
-              value={tokenBValue}
-              maxValue={maxPoolValue}
+              value={tokenBContext?.userReserves.multipliedBy(edgePrice)}
+              maxValue={maxPoolEquivalentReservesA}
             />
           )}
         </td>

--- a/src/components/cards/PoolStakesTableCard.tsx
+++ b/src/components/cards/PoolStakesTableCard.tsx
@@ -50,6 +50,7 @@ import {
 import { useMatchIncentives } from '../../lib/web3/hooks/useIncentives';
 import { RelativeTime } from '../Time';
 import PopOver from '../PopOver/PopOver';
+import ValueBar from '../Table/ValueBar';
 
 interface PoolsTableCardOptions {
   tokenA: Token;
@@ -503,23 +504,22 @@ function StakingRow({
         </td>
         <td>{formatCurrency(tokenAValue.plus(tokenBValue).toNumber())}</td>
         <td className="min-width">
-          <div
-            className={[
-              tokenAValue.isGreaterThan(0)
-                ? 'green-value-bar'
-                : 'blue-value-bar',
-              isStaked && isIncentivized && 'highlighted',
-            ]
-              .filter(Boolean)
-              .join(' ')}
-            style={{
-              width: tokenAValue
-                .plus(tokenBValue)
-                .dividedBy(maxPoolValue)
-                .multipliedBy(50)
-                .toNumber(),
-            }}
-          ></div>
+          {tokenAValue.isGreaterThan(0) && (
+            <ValueBar
+              className={isStaked && isIncentivized && 'highlighted'}
+              variant="green"
+              value={tokenAValue}
+              maxValue={maxPoolValue}
+            />
+          )}
+          {tokenBValue.isGreaterThan(0) && (
+            <ValueBar
+              className={isStaked && isIncentivized && 'highlighted'}
+              variant="blue"
+              value={tokenBValue}
+              maxValue={maxPoolValue}
+            />
+          )}
         </td>
         <td>
           {tokenAContext?.userReserves.isGreaterThan(0) && (

--- a/src/pages/Pool/MyPositionTableCard.tsx
+++ b/src/pages/Pool/MyPositionTableCard.tsx
@@ -12,6 +12,7 @@ import { useSimplePrice } from '../../lib/tokenPrices';
 import { matchTokens } from '../../lib/web3/hooks/useTokens';
 
 import TableCard from '../../components/cards/TableCard';
+import ValueBar from '../../components/Table/ValueBar';
 
 function MyPositionTableCard({
   tokenA,
@@ -122,6 +123,7 @@ export function MyNewPositionTableCard({
             tokenA,
             tokenB
           );
+          const [valueA, valueB] = poolValues[index];
           // note: fix these restrictions, they are a bit off
           return (
             <tr key={index} className="pt-2">
@@ -133,36 +135,26 @@ export function MyNewPositionTableCard({
               </td>
               <td>
                 {reserveA.isGreaterThan(0) && (
-                  <div>{formatCurrency(poolValues[index][0])}</div>
+                  <div>{formatCurrency(valueA)}</div>
                 )}
                 {reserveB.isGreaterThan(0) && (
-                  <div>{formatCurrency(poolValues[index][1])}</div>
+                  <div>{formatCurrency(valueB)}</div>
                 )}
               </td>
               <td className="min-width">
                 {reserveA.isGreaterThan(0) && (
-                  <div
-                    className="green-value-bar"
-                    style={{
-                      width:
-                        new BigNumber(poolValues[index][0])
-                          .dividedBy(maxPoolValue)
-                          .multipliedBy(50)
-                          .toNumber() || 0,
-                    }}
-                  ></div>
+                  <ValueBar
+                    variant="green"
+                    value={valueA}
+                    maxValue={maxPoolValue}
+                  />
                 )}
                 {reserveB.isGreaterThan(0) && (
-                  <div
-                    className="blue-value-bar"
-                    style={{
-                      width:
-                        new BigNumber(poolValues[index][1])
-                          .dividedBy(maxPoolValue)
-                          .multipliedBy(50)
-                          .toNumber() || 0,
-                    }}
-                  ></div>
+                  <ValueBar
+                    variant="blue"
+                    value={valueB}
+                    maxValue={maxPoolValue}
+                  />
                 )}
               </td>
 
@@ -305,6 +297,7 @@ export function MyEditedPositionTableCard({
           const reserveB = !invertedTokenOrder
             ? tickDiff1.plus(token1Context?.userReserves || 0)
             : tickDiff0.plus(token0Context?.userReserves || 0);
+          const [valueA, valueB] = poolValues[index];
 
           const tickIndexBToA = !invertedTokenOrder
             ? new BigNumber(deposit.centerTickIndex1To0.toNumber())
@@ -329,36 +322,26 @@ export function MyEditedPositionTableCard({
               </td>
               <td>
                 {reserveA.isGreaterThan(0) && (
-                  <div>{formatCurrency(poolValues[index][0])}</div>
+                  <div>{formatCurrency(valueA)}</div>
                 )}
                 {reserveB.isGreaterThan(0) && (
-                  <div>{formatCurrency(poolValues[index][1])}</div>
+                  <div>{formatCurrency(valueB)}</div>
                 )}
               </td>
               <td className="min-width">
                 {reserveA.isGreaterThan(0) && (
-                  <div
-                    className="green-value-bar"
-                    style={{
-                      width:
-                        new BigNumber(poolValues[index][0])
-                          .dividedBy(maxPoolValue)
-                          .multipliedBy(50)
-                          .toNumber() || 0,
-                    }}
-                  ></div>
+                  <ValueBar
+                    variant="green"
+                    value={valueA}
+                    maxValue={maxPoolValue}
+                  />
                 )}
                 {reserveB.isGreaterThan(0) && (
-                  <div
-                    className="blue-value-bar"
-                    style={{
-                      width:
-                        new BigNumber(poolValues[index][1])
-                          .dividedBy(maxPoolValue)
-                          .multipliedBy(50)
-                          .toNumber() || 0,
-                    }}
-                  ></div>
+                  <ValueBar
+                    variant="blue"
+                    value={valueB}
+                    maxValue={maxPoolValue}
+                  />
                 )}
               </td>
 

--- a/src/pages/Pool/MyPositionTableCard.tsx
+++ b/src/pages/Pool/MyPositionTableCard.tsx
@@ -144,10 +144,11 @@ export function MyNewPositionTableCard({
                   <div
                     className="green-value-bar"
                     style={{
-                      width: new BigNumber(poolValues[index][0])
-                        .dividedBy(maxPoolValue)
-                        .multipliedBy(50)
-                        .toNumber(),
+                      width:
+                        new BigNumber(poolValues[index][0])
+                          .dividedBy(maxPoolValue)
+                          .multipliedBy(50)
+                          .toNumber() || 0,
                     }}
                   ></div>
                 )}
@@ -155,10 +156,11 @@ export function MyNewPositionTableCard({
                   <div
                     className="blue-value-bar"
                     style={{
-                      width: new BigNumber(poolValues[index][1])
-                        .dividedBy(maxPoolValue)
-                        .multipliedBy(50)
-                        .toNumber(),
+                      width:
+                        new BigNumber(poolValues[index][1])
+                          .dividedBy(maxPoolValue)
+                          .multipliedBy(50)
+                          .toNumber() || 0,
                     }}
                   ></div>
                 )}
@@ -338,10 +340,11 @@ export function MyEditedPositionTableCard({
                   <div
                     className="green-value-bar"
                     style={{
-                      width: new BigNumber(poolValues[index][0])
-                        .dividedBy(maxPoolValue)
-                        .multipliedBy(50)
-                        .toNumber(),
+                      width:
+                        new BigNumber(poolValues[index][0])
+                          .dividedBy(maxPoolValue)
+                          .multipliedBy(50)
+                          .toNumber() || 0,
                     }}
                   ></div>
                 )}
@@ -349,10 +352,11 @@ export function MyEditedPositionTableCard({
                   <div
                     className="blue-value-bar"
                     style={{
-                      width: new BigNumber(poolValues[index][1])
-                        .dividedBy(maxPoolValue)
-                        .multipliedBy(50)
-                        .toNumber(),
+                      width:
+                        new BigNumber(poolValues[index][1])
+                          .dividedBy(maxPoolValue)
+                          .multipliedBy(50)
+                          .toNumber() || 0,
                     }}
                   ></div>
                 )}

--- a/src/pages/Pool/MyPositionTableCard.tsx
+++ b/src/pages/Pool/MyPositionTableCard.tsx
@@ -3,7 +3,10 @@ import BigNumber from 'bignumber.js';
 import { Tick } from '../../components/LiquiditySelector/LiquiditySelector';
 
 import { formatAmount, formatCurrency } from '../../lib/utils/number';
-import { tickIndexToDisplayPrice } from '../../lib/web3/utils/ticks';
+import {
+  tickIndexToPrice,
+  tickIndexToDisplayPrice,
+} from '../../lib/web3/utils/ticks';
 import { Token, getDisplayDenomAmount } from '../../lib/web3/utils/tokens';
 
 import { EditedPosition } from '../MyLiquidity/useEditLiquidity';
@@ -61,10 +64,12 @@ export function MyNewPositionTableCard({
   tokenA,
   tokenB,
   userTicks,
+  edgePriceIndex,
 }: {
   tokenA?: Token;
   tokenB?: Token;
   userTicks: Tick[];
+  edgePriceIndex: number | undefined;
 }) {
   const [reserveATotal, reserveBTotal] = useMemo(() => {
     return [
@@ -81,6 +86,19 @@ export function MyNewPositionTableCard({
 
   const { data: priceA } = useSimplePrice(tokenA);
   const { data: priceB } = useSimplePrice(tokenB);
+
+  const edgpePriceBToA = useMemo(() => {
+    return tickIndexToPrice(new BigNumber(edgePriceIndex || 0));
+  }, [edgePriceIndex]);
+
+  const maxPoolEquivalentReservesA = useMemo(() => {
+    return userTicks.reduce((acc, { reserveA, reserveB }) => {
+      const equivalentReservesA = reserveA?.toNumber() || 0;
+      const equivalentReservesB =
+        reserveB?.multipliedBy(edgpePriceBToA).toNumber() || 0;
+      return Math.max(acc, equivalentReservesA, equivalentReservesB);
+    }, 0);
+  }, [userTicks, edgpePriceBToA]);
 
   const poolValues = useMemo(() => {
     return userTicks.map<[number, number]>(
@@ -99,13 +117,6 @@ export function MyNewPositionTableCard({
       }
     );
   }, [userTicks, priceA, priceB]);
-
-  const maxPoolValue = useMemo(() => {
-    return poolValues.reduce(
-      (acc, [valueA, valueB]) => Math.max(acc, valueA, valueB),
-      0
-    );
-  }, [poolValues]);
 
   const valueTotal = useMemo(() => {
     return poolValues.reduce(
@@ -133,6 +144,7 @@ export function MyNewPositionTableCard({
                   ? formatAmount(displayPriceBToA.toNumber())
                   : '-'}
               </td>
+              {/* this shows the USD equivalent value of the token reserves */}
               <td>
                 {reserveA.isGreaterThan(0) && (
                   <div>{formatCurrency(valueA)}</div>
@@ -141,19 +153,24 @@ export function MyNewPositionTableCard({
                   <div>{formatCurrency(valueB)}</div>
                 )}
               </td>
+              {/*
+               * this shows the reserveA equivalent value of the token reserves
+               * (not USD equivalent) because there may not be a USD price
+               */}
               <td className="min-width">
                 {reserveA.isGreaterThan(0) && (
                   <ValueBar
                     variant="green"
-                    value={valueA}
-                    maxValue={maxPoolValue}
+                    value={reserveA}
+                    maxValue={maxPoolEquivalentReservesA}
                   />
                 )}
+                {/* this looks weird, but its only because of the inconsistent use of individual priceBToA and edgePrice */}
                 {reserveB.isGreaterThan(0) && (
                   <ValueBar
                     variant="blue"
-                    value={valueB}
-                    maxValue={maxPoolValue}
+                    value={reserveB.multipliedBy(edgpePriceBToA)}
+                    maxValue={maxPoolEquivalentReservesA}
                   />
                 )}
               </td>
@@ -209,6 +226,7 @@ export function MyEditedPositionTableCard({
   setEditedUserPosition,
   viewableMinIndex,
   viewableMaxIndex,
+  edgePriceIndex,
 }: {
   tokenA: Token;
   tokenB: Token;
@@ -216,6 +234,7 @@ export function MyEditedPositionTableCard({
   setEditedUserPosition: React.Dispatch<React.SetStateAction<EditedPosition[]>>;
   viewableMinIndex: number | undefined;
   viewableMaxIndex: number | undefined;
+  edgePriceIndex: number | undefined;
 }) {
   const invertedTokenOrder = guessInvertedOrder(tokenA.address, tokenB.address);
 
@@ -236,6 +255,29 @@ export function MyEditedPositionTableCard({
         })
     );
   }, [editedUserPosition, invertedTokenOrder]);
+
+  const edgpePriceBToA = useMemo(() => {
+    return tickIndexToPrice(new BigNumber(edgePriceIndex || 0));
+  }, [edgePriceIndex]);
+
+  const maxPoolEquivalentReservesA = useMemo(() => {
+    return sortedPosition.reduce(
+      (acc, { token0, token0Context, token1Context }) => {
+        const tokenAContext = matchTokens(tokenA, token0)
+          ? token0Context
+          : token1Context;
+        const tokenBContext = matchTokens(tokenB, token0)
+          ? token0Context
+          : token1Context;
+        const equivalentReserveA = tokenAContext?.userReserves.toNumber() ?? 0;
+        const equivalentReserveB =
+          tokenBContext?.userReserves.multipliedBy(edgpePriceBToA).toNumber() ??
+          0;
+        return Math.max(acc, equivalentReserveA, equivalentReserveB);
+      },
+      0
+    );
+  }, [edgpePriceBToA, sortedPosition, tokenA, tokenB]);
 
   const poolValues = useMemo(() => {
     return sortedPosition.map<[number, number]>(
@@ -270,13 +312,6 @@ export function MyEditedPositionTableCard({
       }
     );
   }, [priceA, priceB, tokenA, tokenB, sortedPosition]);
-
-  const maxPoolValue = useMemo(() => {
-    return poolValues.reduce(
-      (acc, [valueA, valueB]) => Math.max(acc, valueA, valueB),
-      0
-    );
-  }, [poolValues]);
 
   const valueTotal = useMemo(() => {
     return poolValues.reduce(
@@ -320,6 +355,7 @@ export function MyEditedPositionTableCard({
                   ? formatAmount(displayPriceBToA.toNumber())
                   : '-'}
               </td>
+              {/* this shows the USD equivalent value of the token reserves */}
               <td>
                 {reserveA.isGreaterThan(0) && (
                   <div>{formatCurrency(valueA)}</div>
@@ -328,19 +364,23 @@ export function MyEditedPositionTableCard({
                   <div>{formatCurrency(valueB)}</div>
                 )}
               </td>
+              {/*
+               * this shows the reserveA equivalent value of the token reserves
+               * (not USD equivalent) because there may not be a USD price
+               */}
               <td className="min-width">
                 {reserveA.isGreaterThan(0) && (
                   <ValueBar
                     variant="green"
-                    value={valueA}
-                    maxValue={maxPoolValue}
+                    value={reserveA}
+                    maxValue={maxPoolEquivalentReservesA}
                   />
                 )}
                 {reserveB.isGreaterThan(0) && (
                   <ValueBar
                     variant="blue"
-                    value={valueB}
-                    maxValue={maxPoolValue}
+                    value={reserveB.multipliedBy(edgpePriceBToA)}
+                    maxValue={maxPoolEquivalentReservesA}
                   />
                 )}
               </td>

--- a/src/pages/Pool/PoolManagement.tsx
+++ b/src/pages/Pool/PoolManagement.tsx
@@ -1627,12 +1627,14 @@ export default function PoolManagement({
                 setEditedUserPosition={setEditedUserPosition}
                 viewableMinIndex={viewableMinIndex}
                 viewableMaxIndex={viewableMaxIndex}
+                edgePriceIndex={edgePriceIndex}
               />
             ) : (
               <MyNewPositionTableCard
                 tokenA={tokenA}
                 tokenB={tokenB}
                 userTicks={userTicks}
+                edgePriceIndex={edgePriceIndex}
               />
             )}
           </div>

--- a/src/styles/globals.scss
+++ b/src/styles/globals.scss
@@ -255,28 +255,6 @@ hr {
   opacity: 0.5;
 }
 
-.red-value-bar {
-  height: 1rem;
-  background-color: hsl(0deg, 50%, 37%);
-  &.highlighted {
-    background-color: hsl(0, 77%, 61%);
-  }
-}
-.green-value-bar {
-  height: 1rem;
-  background-color: hsl(182, 50%, 37%);
-  &.highlighted {
-    background-color: hsl(182, 77%, 61%);
-  }
-}
-.blue-value-bar {
-  height: 1rem;
-  background-color: hsl(202, 50%, 37%);
-  &.highlighted {
-    background-color: hsl(202, 77%, 61%);
-  }
-}
-
 // add a tiny faint shadow to all token logos
 // this helps if a token image background matches the surrounding area
 .token-logo {


### PR DESCRIPTION
Tables and ValueBar components sometimes show toke "value" based on USD value, however this is not a great representation because sometimes USD prices may not be available, they should instead be based upon token reserve amounts and the values calculate from the token pair price-ratio.

This PR shows "value" represented with the ValueBar component, in the dimension of "equivalent reserves A" and the current price. It is important not to graph the value using each position's tick value, as this number will always skew the results to one side when faced with extreme values away from 0. 