### PR TITLE
fix: improve IBC token usage: do not require address field

### DIFF
--- a/.env.deploy-previews
+++ b/.env.deploy-previews
@@ -8,7 +8,7 @@ REACT_APP__DEFAULT_PAIR=NTRN/ATOM
 # Add development tokens
 REACT_APP__DEV_ASSET_MAP={"tokenA":"NTRN/neutron","tokenB":"ATOM/cosmoshub","tokenC":"USDC/ethereum","tokenD":"DAI/gateway","tokenE":"JUNO/juno","tokenF":"STRD/stride","tokenG":"STARS/stargaze","tokenH":"CRE/crescent","tokenI":"HUAHUA/chihuahua","tokenJ":"OSMO/osmosis"}
 # Add prices for development tokens
-REACT_APP__DEV_TOKEN_DENOMS=["token","stake"]
+REACT_APP__DEV_ASSET_PRICE_MAP={"STK":1,"TKN":1}
 
 
 # Override chain name

--- a/.env.development
+++ b/.env.development
@@ -9,7 +9,7 @@ REACT_APP__DEFAULT_PAIR=NTRN/ATOM
 # Add development tokens
 REACT_APP__DEV_ASSET_MAP={"tokenA":"NTRN/neutron","tokenB":"ATOM/cosmoshub","tokenC":"USDC/ethereum","tokenD":"DAI/gateway","tokenE":"HUAHUA/chihuahua"}
 # Add prices for development tokens
-REACT_APP__DEV_TOKEN_DENOMS=["token","stake"]
+REACT_APP__DEV_ASSET_PRICE_MAP={"STK":1,"TKN":1}
 
 # Override chain settings
 REACT_APP__CHAIN_ID=duality-devnet

--- a/src/components/Liquidity/LiquiditySelector.tsx
+++ b/src/components/Liquidity/LiquiditySelector.tsx
@@ -31,6 +31,7 @@ import {
 } from '../../lib/web3/utils/ticks';
 import useCurrentPriceIndexFromTicks from './useCurrentPriceFromTicks';
 import useOnDragMove from '../hooks/useOnDragMove';
+import { getTokenId } from '../../lib/web3/hooks/useTokens';
 
 import './LiquiditySelector.scss';
 
@@ -236,14 +237,16 @@ export default function LiquiditySelector({
     );
 
   const [token0Address, token1Address] =
-    useOrderedTokenPair([tokenA?.address, tokenB?.address]) || [];
+    useOrderedTokenPair([getTokenId(tokenA), getTokenId(tokenB)]) || [];
   const {
     data: [token0Ticks = [], token1Ticks = []],
   } = useTokenPairTickLiquidity([token0Address, token1Address]);
 
   const [forward, reverse] = [
-    token0Address === tokenA?.address && token1Address === tokenB?.address,
-    token1Address === tokenA?.address && token0Address === tokenB?.address,
+    token0Address === getTokenId(tokenA) &&
+      token1Address === getTokenId(tokenB),
+    token1Address === getTokenId(tokenA) &&
+      token0Address === getTokenId(tokenB),
   ];
 
   // translate ticks from token0/1 to tokenA/B
@@ -285,8 +288,8 @@ export default function LiquiditySelector({
   //       (if no existing ticks exist only cuurent price can indicate start and end)
 
   const currentPriceIndexFromTicks = useCurrentPriceIndexFromTicks(
-    tokenA?.address,
-    tokenB?.address
+    getTokenId(tokenA),
+    getTokenId(tokenB)
   );
 
   const isUserTicksAZero =

--- a/src/components/Liquidity/LiquiditySelector.tsx
+++ b/src/components/Liquidity/LiquiditySelector.tsx
@@ -19,7 +19,7 @@ import {
   roundToSignificantDigits,
   formatPercentage,
 } from '../../lib/utils/number';
-import { Token } from '../../lib/web3/utils/tokens';
+import { Token, getTokenId } from '../../lib/web3/utils/tokens';
 import { useOrderedTokenPair } from '../../lib/web3/hooks/useTokenPairs';
 import { useTokenPairTickLiquidity } from '../../lib/web3/hooks/useTickLiquidity';
 import {
@@ -31,7 +31,6 @@ import {
 } from '../../lib/web3/utils/ticks';
 import useCurrentPriceIndexFromTicks from './useCurrentPriceFromTicks';
 import useOnDragMove from '../hooks/useOnDragMove';
-import { getTokenId } from '../../lib/web3/hooks/useTokens';
 
 import './LiquiditySelector.scss';
 

--- a/src/components/TokenPicker/TokenPicker.tsx
+++ b/src/components/TokenPicker/TokenPicker.tsx
@@ -13,11 +13,10 @@ import BigNumber from 'bignumber.js';
 
 import { useFilteredTokenList } from './hooks';
 import useTokens, {
-  getTokenId,
   useDualityTokens,
   useTokensWithIbcInfo,
 } from '../../lib/web3/hooks/useTokens';
-import { Token } from '../../lib/web3/utils/tokens';
+import { Token, getTokenId } from '../../lib/web3/utils/tokens';
 import useUserTokens from '../../lib/web3/hooks/useUserTokens';
 import { useBankBalanceDisplayAmount } from '../../lib/web3/hooks/useUserBankBalances';
 

--- a/src/components/TokenPicker/hooks.ts
+++ b/src/components/TokenPicker/hooks.ts
@@ -60,7 +60,8 @@ export function useFilteredTokenList(
           [
             token.symbol,
             token.name,
-            token.address,
+            token.base,
+            token.display,
             token.chain.pretty_name,
             token.chain.chain_name,
           ].some((txt) => txt && regexQuery.test(txt))

--- a/src/components/cards/AssetsTableCard.tsx
+++ b/src/components/cards/AssetsTableCard.tsx
@@ -6,7 +6,6 @@ import Dialog from '../Dialog/Dialog';
 
 import TableCard, { TableCardProps } from '../../components/cards/TableCard';
 import useTokens, {
-  getTokenId,
   useTokensWithIbcInfo,
 } from '../../lib/web3/hooks/useTokens';
 import BridgeCard from './BridgeCard';
@@ -15,7 +14,11 @@ import { useFilteredTokenList } from '../../components/TokenPicker/hooks';
 import { dualityChain } from '../../lib/web3/hooks/useChains';
 
 import { formatAmount, formatCurrency } from '../../lib/utils/number';
-import { Token, getDisplayDenomAmount } from '../../lib/web3/utils/tokens';
+import {
+  Token,
+  getDisplayDenomAmount,
+  getTokenId,
+} from '../../lib/web3/utils/tokens';
 
 import './AssetsTableCard.scss';
 

--- a/src/components/cards/BridgeCard.tsx
+++ b/src/components/cards/BridgeCard.tsx
@@ -22,6 +22,7 @@ import {
 
 import { minutes, nanoseconds } from '../../lib/utils/time';
 import { formatAddress } from '../../lib/web3/utils/address';
+import { matchToken } from '../../lib/web3/hooks/useTokens';
 import { formatAmount } from '../../lib/utils/number';
 import {
   Token,
@@ -557,12 +558,12 @@ function LocalChainReserves({
 }) {
   const { address } = useWeb3();
   const allUserBankAssets = useUserBankValues();
-  const userToken = allUserBankAssets.find((tokenCoin) => {
-    return (
-      tokenCoin.token.address === token.address &&
-      tokenCoin.token.chain.chain_id === token.chain.chain_id
-    );
-  });
+  const userToken = useMemo(() => {
+    const tokenMatcher = matchToken(token);
+    return allUserBankAssets.find((tokenCoin) => {
+      return tokenMatcher(tokenCoin.token);
+    });
+  }, [allUserBankAssets, token]);
 
   if (!address) {
     return (

--- a/src/components/cards/IncentivesCard.tsx
+++ b/src/components/cards/IncentivesCard.tsx
@@ -5,7 +5,7 @@ import { Gauge } from '@duality-labs/dualityjs/types/codegen/dualitylabs/duality
 import TableCard from './TableCard';
 
 import './IncentivesCard.scss';
-import useTokens, { matchTokenByAddress } from '../../lib/web3/hooks/useTokens';
+import useTokens, { matchTokenByDenom } from '../../lib/web3/hooks/useTokens';
 import { formatAmount } from '../../lib/utils/number';
 
 export default function IncentivesCard({
@@ -72,7 +72,7 @@ export default function IncentivesCard({
               </tr>
 
               {gauge.coins.map((coin) => {
-                const token = tokens.find(matchTokenByAddress(coin.denom));
+                const token = tokens.find(matchTokenByDenom(coin.denom));
                 return token ? (
                   <tr className="striped" key={`${index}-${coin.denom}`}>
                     <td className="row flex-centered p-3">

--- a/src/components/cards/LimitOrderCard.tsx
+++ b/src/components/cards/LimitOrderCard.tsx
@@ -16,6 +16,7 @@ import {
   Token,
   getBaseDenomAmount,
   getDisplayDenomAmount,
+  getTokenId,
 } from '../../lib/web3/utils/tokens';
 import { dualityMainToken } from '../../lib/web3/hooks/useTokens';
 import {
@@ -143,11 +144,11 @@ function LimitOrder({
   showTriggerPrice?: boolean;
 }) {
   const buyMode = !sellMode;
-  const [token0, token1] =
-    useOrderedTokenPair([tokenA?.address, tokenB?.address]) || [];
+  const [tokenIdA, tokenIdB] = [getTokenId(tokenA), getTokenId(tokenB)];
+  const [tokenId0, tokenId1] = useOrderedTokenPair([tokenIdA, tokenIdB]) || [];
   const {
     data: [token0Ticks, token1Ticks],
-  } = useTokenPairTickLiquidity([token0, token1]);
+  } = useTokenPairTickLiquidity([tokenId0, tokenId1]);
 
   const formState = useContext(LimitOrderFormContext);
   const formSetState = useContext(LimitOrderFormSetContext);
@@ -166,8 +167,8 @@ function LimitOrder({
   const [{ isValidating: isValidatingSwap, error }, swapRequest] = useSwap();
 
   const { data: routerResult } = useRouterResult({
-    tokenA: tokenIn?.address,
-    tokenB: tokenOut?.address,
+    tokenA: getTokenId(tokenIn),
+    tokenB: getTokenId(tokenOut),
     valueA: formState.amount,
     valueB: undefined,
   });
@@ -193,7 +194,7 @@ function LimitOrder({
           routerResult.tickIndexIn.toNumber(),
           routerResult.tickIndexOut.toNumber()
         );
-      const forward = result.tokenIn === token0;
+      const forward = result.tokenIn === tokenId0;
       const ticks = forward ? token1Ticks : token0Ticks;
       const ticksPassed =
         (tickMin !== undefined &&
@@ -230,7 +231,7 @@ function LimitOrder({
       return gasEstimate;
     }
     return undefined;
-  }, [routerResult, token0, token0Ticks, token1Ticks]);
+  }, [routerResult, tokenId0, token0Ticks, token1Ticks]);
 
   const onFormSubmit = useCallback(
     function (event?: React.FormEvent<HTMLFormElement>) {
@@ -266,7 +267,7 @@ function LimitOrder({
       ) {
         // convert to swap request format
         const result = routerResult;
-        const forward = result.tokenIn === token0;
+        const forward = result.tokenIn === tokenId0;
         const tickIndexLimit = tickIndexOut * (forward ? 1 : -1);
         swapRequest(
           {
@@ -323,7 +324,7 @@ function LimitOrder({
       address,
       tokenIn,
       tokenOut,
-      token0,
+      tokenId0,
       gasEstimate,
       swapRequest,
     ]

--- a/src/components/cards/PoolStakesTableCard.tsx
+++ b/src/components/cards/PoolStakesTableCard.tsx
@@ -37,7 +37,7 @@ import IncentivesCard from './IncentivesCard';
 
 import { tickIndexToPrice } from '../../lib/web3/utils/ticks';
 import { guessInvertedOrder } from '../../lib/web3/utils/pairs';
-import { matchTokens } from '../../lib/web3/hooks/useTokens';
+import { getTokenId, matchTokens } from '../../lib/web3/hooks/useTokens';
 import { useCurrentPriceFromTicks } from '../Liquidity/useCurrentPriceFromTicks';
 
 import './PoolsTableCard.scss';
@@ -77,7 +77,10 @@ export default function MyPoolStakesTableCard<T extends string | number>({
     return [...userPositionsShareValues, ...userStakedShareValues];
   }, [userPositionsShareValues, userStakedShareValues]);
 
-  const edgePrice = useCurrentPriceFromTicks(tokenA.address, tokenB.address);
+  const edgePrice = useCurrentPriceFromTicks(
+    getTokenId(tokenA),
+    getTokenId(tokenB)
+  );
 
   const maxPoolEquivalentReservesA = useMemo(() => {
     return edgePrice
@@ -108,7 +111,7 @@ export default function MyPoolStakesTableCard<T extends string | number>({
       amountB: number[];
     }>(
       (acc, userPosition) => {
-        const tokensInverted = tokenA.address !== userPosition.token0.address;
+        const tokensInverted = !matchTokens(tokenA, userPosition.token0);
 
         const { tokenAContext, tokenBContext } = !tokensInverted
           ? {
@@ -338,7 +341,10 @@ export default function MyPoolStakesTableCard<T extends string | number>({
           {hasContext ? (
             allShareValues
               .sort((a, b) => {
-                return !guessInvertedOrder(tokenA.address, tokenB.address)
+                return !guessInvertedOrder(
+                  getTokenId(tokenA),
+                  getTokenId(tokenB)
+                )
                   ? a.deposit.centerTickIndex1To0
                       .subtract(b.deposit.centerTickIndex1To0)
                       .toNumber()
@@ -443,7 +449,10 @@ function StakingRow({
 }) {
   const tokensInverted = !matchTokens(tokenA, userPosition.token0);
 
-  const edgePrice = useCurrentPriceFromTicks(tokenA.address, tokenB.address);
+  const edgePrice = useCurrentPriceFromTicks(
+    getTokenId(tokenA),
+    getTokenId(tokenB)
+  );
   const {
     tokenAContext,
     tokenBContext,

--- a/src/components/cards/PoolStakesTableCard.tsx
+++ b/src/components/cards/PoolStakesTableCard.tsx
@@ -26,7 +26,11 @@ import {
   formatCurrency,
   formatPercentage,
 } from '../../lib/utils/number';
-import { Token, getDisplayDenomAmount } from '../../lib/web3/utils/tokens';
+import {
+  Token,
+  getDisplayDenomAmount,
+  getTokenId,
+} from '../../lib/web3/utils/tokens';
 
 import { usePoolDepositFilterForPair } from '../../lib/web3/hooks/useUserShares';
 import {
@@ -37,7 +41,7 @@ import IncentivesCard from './IncentivesCard';
 
 import { tickIndexToPrice } from '../../lib/web3/utils/ticks';
 import { guessInvertedOrder } from '../../lib/web3/utils/pairs';
-import { getTokenId, matchTokens } from '../../lib/web3/hooks/useTokens';
+import { matchTokens } from '../../lib/web3/hooks/useTokens';
 import { useCurrentPriceFromTicks } from '../Liquidity/useCurrentPriceFromTicks';
 
 import './PoolsTableCard.scss';

--- a/src/components/cards/PoolStakesTableCard.tsx
+++ b/src/components/cards/PoolStakesTableCard.tsx
@@ -341,10 +341,7 @@ export default function MyPoolStakesTableCard<T extends string | number>({
           {hasContext ? (
             allShareValues
               .sort((a, b) => {
-                return !guessInvertedOrder(
-                  getTokenId(tokenA),
-                  getTokenId(tokenB)
-                )
+                return !guessInvertedOrder([tokenA, tokenB])
                   ? a.deposit.centerTickIndex1To0
                       .subtract(b.deposit.centerTickIndex1To0)
                       .toNumber()

--- a/src/components/cards/PoolsTableCard.tsx
+++ b/src/components/cards/PoolsTableCard.tsx
@@ -55,7 +55,7 @@ export default function PoolsTableCard<T extends string | number>({
   const allPairsList = useMemo<Array<PoolTableRow>>(() => {
     return tokenPairs
       ? tokenPairs
-          // find the tokens that match our known pair token addresses
+          // find the tokens that match our known pair token IDs
           .map(([token0, token1, reserves0, reserves1]) => {
             return [
               getPairID(token0, token1),

--- a/src/components/cards/PoolsTableCard.tsx
+++ b/src/components/cards/PoolsTableCard.tsx
@@ -8,8 +8,9 @@ import TableCard, { TableCardProps } from './TableCard';
 import { useSimplePrice } from '../../lib/tokenPrices';
 import { useFilteredTokenList } from '../../components/TokenPicker/hooks';
 import useTokens, {
+  getTokenId,
   getTokenPathPart,
-  matchTokenByAddress,
+  matchTokenByDenom,
   useTokensWithIbcInfo,
 } from '../../lib/web3/hooks/useTokens';
 
@@ -55,8 +56,8 @@ export default function PoolsTableCard<T extends string | number>({
           .map(([token0, token1, reserves0, reserves1]) => {
             return [
               getPairID(token0, token1),
-              tokenList.find(matchTokenByAddress(token0)),
-              tokenList.find(matchTokenByAddress(token1)),
+              tokenList.find(matchTokenByDenom(token0)),
+              tokenList.find(matchTokenByDenom(token1)),
               reserves0,
               reserves1,
             ];
@@ -166,16 +167,16 @@ function PairRow({
 
   const { data: { gauges } = {} } = useIncentiveGauges();
   const incentives = useMemo<Gauge[]>(() => {
-    const tokenAddresses = [token0.address, token1.address].filter(
-      (address): address is string => !!address
+    const tokenIds = [getTokenId(token0), getTokenId(token1)].filter(
+      (id): id is string => !!id
     );
     return gauges && gauges.length > 0
       ? gauges.filter((gauge) => {
-          return tokenAddresses.length > 0
-            ? tokenAddresses.every((address) => {
+          return tokenIds.length > 0
+            ? tokenIds.every((id) => {
                 return (
-                  address === gauge.distribute_to?.pairID?.token0 ||
-                  address === gauge.distribute_to?.pairID?.token1
+                  id === gauge.distribute_to?.pairID?.token0 ||
+                  id === gauge.distribute_to?.pairID?.token1
                 );
               })
             : true;
@@ -256,8 +257,8 @@ export function MyPoolsTableCard<T extends string | number>({
       const { token0: token0Address, token1: token1Address } =
         userPosition.deposit.pairID;
       const pairID = getPairID(token0Address, token1Address);
-      const token0 = tokenList.find(matchTokenByAddress(token0Address));
-      const token1 = tokenList.find(matchTokenByAddress(token1Address));
+      const token0 = tokenList.find(matchTokenByDenom(token0Address));
+      const token1 = tokenList.find(matchTokenByDenom(token1Address));
       if (pairID && token0 && token1) {
         map[pairID] = map[pairID] || { token0, token1, userPositions: [] };
         map[pairID].userPositions.push(userPosition);

--- a/src/components/cards/PoolsTableCard.tsx
+++ b/src/components/cards/PoolsTableCard.tsx
@@ -8,14 +8,17 @@ import TableCard, { TableCardProps } from './TableCard';
 import { useSimplePrice } from '../../lib/tokenPrices';
 import { useFilteredTokenList } from '../../components/TokenPicker/hooks';
 import useTokens, {
-  getTokenId,
   getTokenPathPart,
   matchTokenByDenom,
   useTokensWithIbcInfo,
 } from '../../lib/web3/hooks/useTokens';
 
 import { formatAmount, formatCurrency } from '../../lib/utils/number';
-import { Token, getDisplayDenomAmount } from '../../lib/web3/utils/tokens';
+import {
+  Token,
+  getDisplayDenomAmount,
+  getTokenId,
+} from '../../lib/web3/utils/tokens';
 import useTokenPairs from '../../lib/web3/hooks/useTokenPairs';
 import { getPairID } from '../../lib/web3/utils/pairs';
 

--- a/src/components/cards/PriceCard.tsx
+++ b/src/components/cards/PriceCard.tsx
@@ -6,6 +6,7 @@ import { formatPrice } from '../../lib/utils/number';
 import { useSimplePrice } from '../../lib/tokenPrices';
 
 import './PriceCard.scss';
+import { getTokenId } from '../../lib/web3/hooks/useTokens';
 
 export function PriceCard({
   tokenA,
@@ -50,7 +51,10 @@ export function PairPriceCard({
   tokenA: Token;
   tokenB: Token;
 }) {
-  const currentPrice = useCurrentPriceFromTicks(tokenA.address, tokenB.address);
+  const currentPrice = useCurrentPriceFromTicks(
+    getTokenId(tokenA),
+    getTokenId(tokenB)
+  );
   return (
     <PriceCard
       tokenA={tokenA}

--- a/src/components/cards/PriceCard.tsx
+++ b/src/components/cards/PriceCard.tsx
@@ -1,12 +1,11 @@
 import { ReactNode } from 'react';
 
-import { Token } from '../../lib/web3/utils/tokens';
+import { Token, getTokenId } from '../../lib/web3/utils/tokens';
 import { useCurrentPriceFromTicks } from '../Liquidity/useCurrentPriceFromTicks';
 import { formatPrice } from '../../lib/utils/number';
 import { useSimplePrice } from '../../lib/tokenPrices';
 
 import './PriceCard.scss';
-import { getTokenId } from '../../lib/web3/hooks/useTokens';
 
 export function PriceCard({
   tokenA,

--- a/src/components/stats/hooks.ts
+++ b/src/components/stats/hooks.ts
@@ -10,7 +10,7 @@ import {
   getLastDataChanges,
   getLastDataValues,
 } from './utils';
-import { Token } from '../../lib/web3/utils/tokens';
+import { Token, getTokenId } from '../../lib/web3/utils/tokens';
 import { useTokenValueTotal } from '../../lib/web3/hooks/useTokens';
 import { tickIndexToPrice } from '../../lib/web3/utils/ticks';
 
@@ -111,7 +111,7 @@ function useStatTokenValue(
 
 // Price
 function getStatPricePath(tokenA: Token, tokenB: Token) {
-  return `stats/price/${tokenA.address}/${tokenB.address}`;
+  return `stats/price/${getTokenId(tokenA)}/${getTokenId(tokenB)}`;
 }
 export function useStatPrice(
   tokenA: Token,

--- a/src/components/stats/utils.ts
+++ b/src/components/stats/utils.ts
@@ -1,6 +1,5 @@
 import { formatCurrency, formatPercentage } from '../../lib/utils/number';
-import { getIbcBaseDenom } from '../../lib/web3/hooks/useTokens';
-import { Token } from '../../lib/web3/utils/tokens';
+import { Token, getIbcBaseDenom } from '../../lib/web3/utils/tokens';
 
 // format a URL path part to reference a token on the indexer
 export function getIndexerTokenPathPart(token: Token) {

--- a/src/components/stats/utils.ts
+++ b/src/components/stats/utils.ts
@@ -1,11 +1,9 @@
 import { formatCurrency, formatPercentage } from '../../lib/utils/number';
-import { Token, getIbcBaseDenom } from '../../lib/web3/utils/tokens';
+import { Token, getTokenId } from '../../lib/web3/utils/tokens';
 
 // format a URL path part to reference a token on the indexer
 export function getIndexerTokenPathPart(token: Token) {
-  return encodeURIComponent(
-    (token.ibc ? getIbcBaseDenom(token) : token.base) ?? '-'
-  );
+  return encodeURIComponent(getTokenId(token) || '-');
 }
 
 export type TimeSeriesRow = [unixTime: number, values: number[]];

--- a/src/components/stats/utils.ts
+++ b/src/components/stats/utils.ts
@@ -1,9 +1,12 @@
 import { formatCurrency, formatPercentage } from '../../lib/utils/number';
+import { getIbcBaseDenom } from '../../lib/web3/hooks/useTokens';
 import { Token } from '../../lib/web3/utils/tokens';
 
 // format a URL path part to reference a token on the indexer
 export function getIndexerTokenPathPart(token: Token) {
-  return encodeURIComponent(token.address);
+  return encodeURIComponent(
+    (token.ibc ? getIbcBaseDenom(token) : token.base) ?? '-'
+  );
 }
 
 export type TimeSeriesRow = [unixTime: number, values: number[]];

--- a/src/lib/tokenPrices.ts
+++ b/src/lib/tokenPrices.ts
@@ -9,9 +9,9 @@ const { REACT_APP__DEV_TOKEN_DENOMS } = process.env;
 
 const baseAPI = 'https://api.coingecko.com/api/v3';
 
-// identify dev tokens using a specific dev chain name
+// identify dev tokens using a specific dev chain id
 function isDevToken(token?: Token) {
-  return !!token && token.chain === devChain;
+  return !!devChain && !!token && token.chain?.chain_id === devChain?.chain_id;
 }
 
 class FetchError extends Error {

--- a/src/lib/tokenPrices.ts
+++ b/src/lib/tokenPrices.ts
@@ -5,8 +5,6 @@ import { ObservableList, useObservableList } from './utils/observableList';
 import { Token } from './web3/utils/tokens';
 import { devChain } from './web3/hooks/useChains';
 
-const { REACT_APP__DEV_TOKEN_DENOMS } = process.env;
-
 const baseAPI = 'https://api.coingecko.com/api/v3';
 
 // identify dev tokens using a specific dev chain id
@@ -208,35 +206,13 @@ export function usePairPrice(
   };
 }
 
-// add dev logic for assuming dev tokens TKN and STK are worth ~USD1
-function useDevTokenPrices(
-  tokenOrTokens: (Token | undefined) | (Token | undefined)[]
-) {
-  const tokens = Array.isArray(tokenOrTokens) ? tokenOrTokens : [tokenOrTokens];
-  // declare dev tokens for each environment
-  const devPrice = 1;
-  const devTokenPrices = Array.isArray(tokenOrTokens)
-    ? tokens.map(() => devPrice)
-    : devPrice;
-  try {
-    const devTokens = JSON.parse(
-      REACT_APP__DEV_TOKEN_DENOMS || '[]'
-    ) as string[];
-    if (tokens.every((token) => token && devTokens.includes(token.base))) {
-      return devTokenPrices;
-    }
-  } catch {
-    return devTokenPrices;
-  }
-}
-
 export function useHasPriceData(
   tokens: (Token | undefined)[],
   currencyID = 'usd'
 ) {
   const { data, isValidating } = useSimplePrice(tokens, currencyID);
-  // do not claim price data for dev tokens
-  if (useDevTokenPrices(tokens)) {
+  // do not claim price data if tokens won't use any CoinGecko lookups
+  if (tokens.every((token) => !!token?.coingecko_id)) {
     return false;
   }
   return isValidating || data.some(Boolean);

--- a/src/lib/web3/hooks/useChains.ts
+++ b/src/lib/web3/hooks/useChains.ts
@@ -10,6 +10,7 @@ import { QueryBalanceResponse } from '@duality-labs/dualityjs/types/codegen/cosm
 import { State as ChannelState } from '@duality-labs/dualityjs/types/codegen/ibc/core/channel/v1/channel';
 import { State as ConnectionState } from '@duality-labs/dualityjs/types/codegen/ibc/core/connection/v1/connection';
 import { useQuery } from '@tanstack/react-query';
+import { useDeepCompareMemoize } from 'use-deep-compare-effect';
 
 import { getChainInfo } from '../wallets/keplr';
 import dualityLogo from '../../../assets/logo/logo.svg';
@@ -178,13 +179,16 @@ function filterChannelsOpen(
 }
 
 export function useIbcOpenTransfers(chain: Chain = dualityChain) {
-  const { data: { client_states } = {} } = useIbcClientStates(chain);
-  const { data: { connections } = {} } = useIbcConnections(chain);
-  const { data: { channels } = {} } = useIbcChannels(chain);
+  const { data: clientStateData } = useIbcClientStates(chain);
+  const { data: connectionData } = useIbcConnections(chain);
+  const { data: channelData } = useIbcChannels(chain);
 
+  const clientStates = useDeepCompareMemoize(clientStateData?.client_states);
+  const connections = useDeepCompareMemoize(connectionData?.connections);
+  const channels = useDeepCompareMemoize(channelData?.channels);
   return useMemo(() => {
     // get openClients (all listed clients are assumed to be working)
-    const openClients = client_states || [];
+    const openClients = clientStates || [];
     // get open connections
     const openConnections = (connections || []).filter(filterConnectionsOpen);
     // get open channels
@@ -217,7 +221,7 @@ export function useIbcOpenTransfers(chain: Chain = dualityChain) {
           })
       );
     });
-  }, [client_states, connections, channels]);
+  }, [clientStates, connections, channels]);
 }
 
 export function useConnectedChainIDs(chain: Chain = dualityChain) {

--- a/src/lib/web3/hooks/useChains.ts
+++ b/src/lib/web3/hooks/useChains.ts
@@ -13,10 +13,9 @@ import { useQuery } from '@tanstack/react-query';
 
 import { getChainInfo } from '../wallets/keplr';
 import dualityLogo from '../../../assets/logo/logo.svg';
-import { Token } from '../utils/tokens';
+import { Token, getTokenId } from '../utils/tokens';
 import { minutes } from '../../utils/time';
 import Long from 'long';
-import { getTokenId } from './useTokens';
 
 interface QueryConnectionParamsResponse {
   params?: QueryConnectionParams;

--- a/src/lib/web3/hooks/useChains.ts
+++ b/src/lib/web3/hooks/useChains.ts
@@ -125,6 +125,7 @@ function useIbcClientStates(chain: Chain) {
       );
     },
     refetchInterval: 5 * minutes,
+    refetchOnMount: false,
   });
 }
 
@@ -144,6 +145,7 @@ function useIbcConnections(chain: Chain) {
       );
     },
     refetchInterval: 5 * minutes,
+    refetchOnMount: false,
   });
 }
 
@@ -163,6 +165,7 @@ function useIbcChannels(chain: Chain) {
       );
     },
     refetchInterval: 5 * minutes,
+    refetchOnMount: false,
   });
 }
 
@@ -267,6 +270,7 @@ export function useRemoteChainRpcEndpoint(chain?: Chain) {
       }
     },
     refetchInterval: false,
+    refetchOnMount: false,
   });
 }
 
@@ -307,6 +311,7 @@ export function useRemoteChainRestEndpoint(chain?: Chain) {
       }
     },
     refetchInterval: false,
+    refetchOnMount: false,
   });
 }
 

--- a/src/lib/web3/hooks/useChains.ts
+++ b/src/lib/web3/hooks/useChains.ts
@@ -16,6 +16,7 @@ import dualityLogo from '../../../assets/logo/logo.svg';
 import { Token } from '../utils/tokens';
 import { minutes } from '../../utils/time';
 import Long from 'long';
+import { getTokenId } from './useTokens';
 
 interface QueryConnectionParamsResponse {
   params?: QueryConnectionParams;
@@ -312,26 +313,21 @@ export function useRemoteChainBankBalance(
   address?: string
 ) {
   const { data: restEndpoint } = useRemoteChainRestEndpoint(chain);
+  // optionally find the IBC denom when querying the Duality chain
+  const denom =
+    restEndpoint === REACT_APP__REST_API
+      ? getTokenId(token)
+      : // query the base denom of any external chains
+        token?.base;
   return useQuery({
-    enabled: !!token,
+    enabled: !!denom,
     queryKey: ['cosmos-chain-endpoints', restEndpoint, address],
     queryFn: async (): Promise<QueryBalanceResponse | null> => {
-      if (restEndpoint && address && token) {
+      if (restEndpoint && address && denom) {
         const client = await ibc.ClientFactory.createLCDClient({
           restEndpoint,
         });
-        // optionally find the IBC denom when querying the Duality chain
-        const denom =
-          restEndpoint === REACT_APP__REST_API
-            ? token.denom_units
-                .find((unit) => unit.denom === token.base)
-                ?.aliases?.find((alias) => alias.startsWith('ibc/')) ??
-              token.base
-            : token.base;
-        return client.cosmos.bank.v1beta1.balance({
-          address,
-          denom,
-        });
+        return client.cosmos.bank.v1beta1.balance({ address, denom });
       } else {
         return null;
       }

--- a/src/lib/web3/hooks/useIncentives.ts
+++ b/src/lib/web3/hooks/useIncentives.ts
@@ -13,7 +13,7 @@ import { Coin } from '@duality-labs/dualityjs/types/codegen/cosmos/base/v1beta1/
 import subscriber from '../subscriptionManager';
 import { ValuedUserPositionDepositContext } from './useUserShareValues';
 import { minutes } from '../../utils/time';
-import { getTokenId } from './useTokens';
+import { getTokenId } from '../utils/tokens';
 
 const {
   REACT_APP__REST_API = '',

--- a/src/lib/web3/hooks/useIncentives.ts
+++ b/src/lib/web3/hooks/useIncentives.ts
@@ -13,6 +13,7 @@ import { Coin } from '@duality-labs/dualityjs/types/codegen/cosmos/base/v1beta1/
 import subscriber from '../subscriptionManager';
 import { ValuedUserPositionDepositContext } from './useUserShareValues';
 import { minutes } from '../../utils/time';
+import { getTokenId } from './useTokens';
 
 const {
   REACT_APP__REST_API = '',
@@ -79,8 +80,8 @@ function isIncentiveMatch(
   if (pairID && startTick !== undefined && endTick !== undefined) {
     return (
       // is this the correct tick pair?
-      pairID.token0 === userPosition.token0.address &&
-      pairID.token1 === userPosition.token1.address &&
+      pairID.token0 === getTokenId(userPosition.token0) &&
+      pairID.token1 === getTokenId(userPosition.token1) &&
       // are ticks within bounds?
       userPosition.deposit.lowerTickIndex1To0.greaterThanOrEqual(startTick) &&
       userPosition.deposit.upperTickIndex1To0.lessThanOrEqual(endTick)

--- a/src/lib/web3/hooks/useTickLiquidity.ts
+++ b/src/lib/web3/hooks/useTickLiquidity.ts
@@ -6,27 +6,24 @@ import { TickInfo, tickIndexToPrice } from '../utils/ticks';
 import { useOrderedTokenPair } from './useTokenPairs';
 import { useToken } from '../../../lib/web3/hooks/useTokens';
 
-import { Token, TokenAddress } from '../utils/tokens';
 import { useIndexerStreamOfDualDataSet } from './useIndexer';
+import { Token, TokenID } from '../utils/tokens';
 
 type ReserveDataRow = [tickIndex: number, reserves: number];
 
 // add convenience method to fetch ticks in a pair
-export function useTokenPairTickLiquidity([tokenAddressA, tokenAddressB]: [
-  TokenAddress?,
-  TokenAddress?
+export function useTokenPairTickLiquidity([tokenIdA, tokenIdB]: [
+  TokenID?,
+  TokenID?
 ]): {
   data: [TickInfo[] | undefined, TickInfo[] | undefined];
   isValidating: boolean;
   error: unknown;
 } {
-  const [token0Address, token1Address] =
-    useOrderedTokenPair([tokenAddressA, tokenAddressB]) || [];
+  const [tokenId0, tokenId1] = useOrderedTokenPair([tokenIdA, tokenIdB]) || [];
   // stream data from indexer
   const { data, error } = useIndexerStreamOfDualDataSet<ReserveDataRow>(
-    tokenAddressA &&
-      tokenAddressB &&
-      `/liquidity/pair/${tokenAddressA}/${tokenAddressB}`,
+    tokenIdA && tokenIdB && `/liquidity/pair/${tokenIdA}/${tokenIdB}`,
     {
       // remove entries of value 0 from the accumulated map, they are not used
       mapEntryRemovalValue: 0,
@@ -34,8 +31,8 @@ export function useTokenPairTickLiquidity([tokenAddressA, tokenAddressB]: [
   );
 
   // add token context into pool reserves
-  const token0 = useToken(token0Address);
-  const token1 = useToken(token1Address);
+  const token0 = useToken(tokenId0);
+  const token1 = useToken(tokenId1);
 
   // add token context into pool reserves
   const [tickInfoA, tickInfoB] = useMemo<

--- a/src/lib/web3/hooks/useTokenPairs.ts
+++ b/src/lib/web3/hooks/useTokenPairs.ts
@@ -1,10 +1,10 @@
 import { useMemo } from 'react';
-import { TokenAddress } from '../utils/tokens';
+import { TokenID } from '../utils/tokens';
 import { useIndexerStreamOfSingleDataSet } from './useIndexer';
 
 export type TokenPairReserves = [
-  token0: TokenAddress,
-  token1: TokenAddress,
+  token0: TokenID,
+  token1: TokenID,
   reserve0: number,
   reserve1: number
 ];
@@ -34,8 +34,8 @@ export default function useTokenPairs(): TokenPairsState {
 
 // add convenience method to fetch ticks in a pair
 export function useOrderedTokenPair([tokenA, tokenB]: [
-  TokenAddress?,
-  TokenAddress?
+  tokenA?: TokenID,
+  tokenB?: TokenID
 ]): TokenPairReserves | undefined {
   const { data: tokenPairs } = useTokenPairs();
   // search for ordered token pair in our token pair list

--- a/src/lib/web3/hooks/useTokens.ts
+++ b/src/lib/web3/hooks/useTokens.ts
@@ -120,10 +120,6 @@ export const devAssets: AssetList | undefined = REACT_APP__DEV_ASSET_MAP
               chain: devChain,
               // fix: remove clashing TypeScript types
               traces: undefined,
-              // overwrite address for token matching
-              address: tokenId,
-              // mark as a dev asset
-              type_asset: '___dev___',
               // overwrite base denom for denom matching in Keplr fees
               base: tokenId,
               // add denom alias for denom exponent matching

--- a/src/lib/web3/hooks/useTokens.ts
+++ b/src/lib/web3/hooks/useTokens.ts
@@ -7,6 +7,7 @@ import {
 import { Asset, AssetList, Chain } from '@chain-registry/types';
 import {
   Token,
+  TokenID,
   getIbcBaseDenom,
   getIbcDenom,
   getTokenId,
@@ -40,7 +41,6 @@ type TokenList = Array<Token>;
 export const dualityMainToken: Token = {
   chain: devChain,
   description: 'SDK default token',
-  address: 'token',
   denom_units: [
     {
       denom: 'token',
@@ -65,7 +65,6 @@ export const dualityMainToken: Token = {
 export const dualityStakeToken: Token = {
   chain: devChain,
   description: 'SDK default token',
-  address: 'stake',
   denom_units: [
     {
       denom: 'stake',
@@ -104,8 +103,8 @@ export const devAssets: AssetList | undefined = REACT_APP__DEV_ASSET_MAP
   ? {
       chain_name: devChain.chain_name,
       assets: Object.entries(
-        JSON.parse(REACT_APP__DEV_ASSET_MAP) as { [address: string]: string }
-      ).flatMap<Asset>(([address, path]) => {
+        JSON.parse(REACT_APP__DEV_ASSET_MAP) as { [tokenId: TokenID]: string }
+      ).flatMap<Asset>(([tokenId, path]) => {
         const devChainName = devChain.chain_name;
         const [symbol, chainName = devChainName] = path.split('/');
         const foundAssetList = chainRegistryAssetList.find(
@@ -114,7 +113,7 @@ export const devAssets: AssetList | undefined = REACT_APP__DEV_ASSET_MAP
         const foundAsset = foundAssetList?.assets.find((asset) => {
           return asset.symbol === symbol;
         });
-        // overwrite chain asset with fake address of dev chain
+        // overwrite chain asset with fake tokenId of dev chain
         return foundAsset
           ? {
               ...foundAsset,
@@ -122,16 +121,18 @@ export const devAssets: AssetList | undefined = REACT_APP__DEV_ASSET_MAP
               // fix: remove clashing TypeScript types
               traces: undefined,
               // overwrite address for token matching
-              address,
+              address: tokenId,
+              // mark as a dev asset
+              type_asset: '___dev___',
               // overwrite base denom for denom matching in Keplr fees
-              base: address,
+              base: tokenId,
               // add denom alias for denom exponent matching
               denom_units: foundAsset.denom_units.map((unit) => {
                 return unit.denom === foundAsset.base
                   ? // add token as base denom, move original denom to aliases
                     {
                       ...unit,
-                      denom: address,
+                      denom: tokenId,
                       aliases: [...(unit.aliases || []), unit.denom],
                     }
                   : unit;

--- a/src/lib/web3/hooks/useTokens.ts
+++ b/src/lib/web3/hooks/useTokens.ts
@@ -149,7 +149,11 @@ const assetList = [
   providerAssets,
   // add any dev assets added to the environment
   isTestnet && devAssets,
-].filter((assets): assets is AssetList => !!assets);
+]
+  .filter((assets): assets is AssetList => !!assets)
+  // remove duplicate assets
+  // todo: work out how to include terra assets without duplication
+  .filter((assets) => !assets.chain_name.startsWith('terra'));
 const chainList = [
   ...chainRegistryChainList,
   dualityChain,

--- a/src/lib/web3/hooks/useTokens.ts
+++ b/src/lib/web3/hooks/useTokens.ts
@@ -352,6 +352,14 @@ function getTokenSymbol(token: Token | undefined): string | undefined {
   // return IBC denom or the local token symbol as the token identifier
   return token?.ibc ? getIbcBaseDenom(token) : token?.symbol;
 }
+export function getTokenId(token: Token | undefined): string | undefined {
+  // return IBC base denom or the local token base denom as the token identifier
+  if (token?.ibc) {
+    return getIbcBaseDenom(token);
+  } else if (token?.chain.chain_id === REACT_APP__CHAIN_ID) {
+    return token?.base;
+  }
+}
 // return token identifier that can be used as a part of a URL
 // (for later decoding by matchTokenBySymbol and useTokenBySymbol)
 export function getTokenPathPart(token: Token | undefined) {

--- a/src/lib/web3/hooks/useTokens.ts
+++ b/src/lib/web3/hooks/useTokens.ts
@@ -5,7 +5,14 @@ import {
   chains as chainRegistryChainList,
 } from 'chain-registry';
 import { Asset, AssetList, Chain } from '@chain-registry/types';
-import { Token, getIbcDenom, getTokenValue } from '../utils/tokens';
+import {
+  Token,
+  getIbcBaseDenom,
+  getIbcDenom,
+  getTokenId,
+  getTokenValue,
+  ibcDenomRegex,
+} from '../utils/tokens';
 import { useSimplePrice } from '../../tokenPrices';
 import {
   devChain,
@@ -166,6 +173,11 @@ const tokenListCache: {
   [key: string]: TokenList;
 } = {};
 
+function defaultSort(a: Token, b: Token) {
+  // compare by symbol name
+  return a.symbol.localeCompare(b.symbol);
+}
+
 const allTokens = () => true;
 export default function useTokens(sortFunction = defaultSort) {
   tokenListCache['allTokens'] =
@@ -290,7 +302,6 @@ export function useTokensWithIbcInfo(tokenList: Token[]) {
   }, [tokenList, ibcOpenTransfersInfo]);
 }
 
-const ibcDenomRegex = /^ibc\/[0-9A-Fa-f]+$/;
 // allow matching by token symbol or IBC denom string (typically from a URL)
 function matchTokenBySymbol(symbol: string | undefined) {
   // match nothing
@@ -329,32 +340,10 @@ export function useTokenBySymbol(symbol: string | undefined) {
   return tokensWithIbcInfo.find(matchTokenBySymbol(symbol));
 }
 
-export function getIbcBaseDenom(token: Token | undefined): string | undefined {
-  const ibcDenom = token?.ibc?.source_denom;
-  // return the source IBC denom if it is found
-  if (ibcDenom) {
-    const baseUnit = token.denom_units.find((unit) => unit.denom === ibcDenom);
-    // return the denom that matches an appended IBC denom alias
-    if (baseUnit) {
-      return baseUnit.aliases?.find((alias) => alias.match(ibcDenomRegex));
-    }
-  }
-}
-
 // get a "symbol" string that can be later decoded by matchTokenBySymbol
 function getTokenSymbol(token: Token | undefined): string | undefined {
   // return IBC denom or the local token symbol as the token identifier
   return token?.ibc ? getIbcBaseDenom(token) : token?.symbol;
-}
-// the token ID is what is the Duality chain uses as the identifying string of its denoms
-// it is basically the base denom in local or IBC string format
-export function getTokenId(token: Token | undefined): string | undefined {
-  // return IBC base denom or the local token base denom as the token identifier
-  if (token?.ibc) {
-    return getIbcBaseDenom(token);
-  } else if (token?.chain.chain_id === REACT_APP__CHAIN_ID) {
-    return token?.base;
-  }
 }
 // return token identifier that can be used as a part of a URL
 // (for later decoding by matchTokenBySymbol and useTokenBySymbol)
@@ -364,11 +353,6 @@ export function getTokenPathPart(token: Token | undefined) {
 
 export function useTokenPathPart(token: Token | undefined) {
   return useMemo(() => getTokenPathPart(token), [token]);
-}
-
-function defaultSort(a: Token, b: Token) {
-  // compare by symbol name
-  return a.symbol.localeCompare(b.symbol);
 }
 
 export function matchToken(tokenSearch: Token) {

--- a/src/lib/web3/hooks/useTokens.ts
+++ b/src/lib/web3/hooks/useTokens.ts
@@ -244,14 +244,10 @@ export function useTokensWithIbcInfo(tokenList: Token[]) {
   return useMemo(() => {
     return (
       tokenList
-        // add IBC denom information
-        .map((token) => {
+        // remove existing IBC informations and add new IBC denom information
+        .map(({ ibc, ...token }) => {
           // return unchanged tokens from native chain
           if (token.chain.chain_id === dualityChain.chain_id) {
-            return token;
-          }
-          // if IBC information already exists, do not re-append it
-          if (token.ibc) {
             return token;
           }
           // append ibcDenom as a denom alias

--- a/src/lib/web3/hooks/useTokens.ts
+++ b/src/lib/web3/hooks/useTokens.ts
@@ -311,7 +311,12 @@ function matchTokenBySymbol(symbol: string | undefined) {
   // match regular symbols for local tokens
   else {
     return (token: Token) => {
-      return token.symbol === symbol;
+      return (
+        // match Duaity chain
+        token.chain.chain_id === REACT_APP__CHAIN_ID &&
+        // match symbol
+        token.symbol === symbol
+      );
     };
   }
 }

--- a/src/lib/web3/hooks/useTokens.ts
+++ b/src/lib/web3/hooks/useTokens.ts
@@ -229,13 +229,13 @@ export function useIbcTokens(sortFunction = defaultSort) {
 }
 
 export function useToken(
-  tokenAddress: string | undefined,
+  denom: string | undefined,
   matchFunction = matchTokenByDenom
 ): Token | undefined {
   const tokens = useTokensWithIbcInfo(useTokens());
   return useMemo(() => {
-    return tokenAddress ? tokens.find(matchFunction(tokenAddress)) : undefined;
-  }, [matchFunction, tokenAddress, tokens]);
+    return denom ? tokens.find(matchFunction(denom)) : undefined;
+  }, [matchFunction, denom, tokens]);
 }
 
 // connected IBC info into given token list

--- a/src/lib/web3/hooks/useUserShareValues.ts
+++ b/src/lib/web3/hooks/useUserShareValues.ts
@@ -1,6 +1,6 @@
 import BigNumber from 'bignumber.js';
 import { useMemo } from 'react';
-import useTokens from './useTokens';
+import useTokens, { getTokenId, matchTokenByDenom } from './useTokens';
 import { useSimplePrice } from '../../tokenPrices';
 import { Token, getDisplayDenomAmount } from '../utils/tokens';
 import {
@@ -59,8 +59,9 @@ export function useUserPositionsShareValues(
     return selectedTokens.reduce<{
       [tokenAddress: string]: number | undefined;
     }>((acc, token, index) => {
-      if (token.address) {
-        acc[token.address] = selectedTokensPrices[index];
+      const tokenId = getTokenId(token);
+      if (tokenId) {
+        acc[tokenId] = selectedTokensPrices[index];
       }
       return acc;
     }, {});
@@ -82,12 +83,10 @@ export function useUserPositionsShareValues(
     function getValueOfContext(
       context: ShareValueContext
     ): BigNumber | undefined {
-      const { token: tokenAddress, userReserves } = context;
+      const { token: tokenDenom, userReserves } = context;
       // what is the price per token?
-      const token = selectedTokens.find(
-        ({ address }) => address === tokenAddress
-      );
-      const price = selectedTokensPriceMap[tokenAddress];
+      const token = selectedTokens.find(matchTokenByDenom(tokenDenom));
+      const price = selectedTokensPriceMap[getTokenId(token) || ''];
       if (token && price && !isNaN(price)) {
         // how many tokens does the user have?
         const amount = getDisplayDenomAmount(token, userReserves);

--- a/src/lib/web3/hooks/useUserShareValues.ts
+++ b/src/lib/web3/hooks/useUserShareValues.ts
@@ -1,8 +1,8 @@
 import BigNumber from 'bignumber.js';
 import { useMemo } from 'react';
-import useTokens, { getTokenId, matchTokenByDenom } from './useTokens';
+import useTokens, { matchTokenByDenom } from './useTokens';
 import { useSimplePrice } from '../../tokenPrices';
-import { Token, getDisplayDenomAmount } from '../utils/tokens';
+import { Token, getDisplayDenomAmount, getTokenId } from '../utils/tokens';
 import {
   ShareValueContext,
   UserDepositFilter,

--- a/src/lib/web3/hooks/useUserShareValues.ts
+++ b/src/lib/web3/hooks/useUserShareValues.ts
@@ -57,7 +57,7 @@ export function useUserPositionsShareValues(
 
   const selectedTokensPriceMap = useMemo(() => {
     return selectedTokens.reduce<{
-      [tokenAddress: string]: number | undefined;
+      [tokenId: string]: number | undefined;
     }>((acc, token, index) => {
       const tokenId = getTokenId(token);
       if (tokenId) {

--- a/src/lib/web3/hooks/useUserShares.ts
+++ b/src/lib/web3/hooks/useUserShares.ts
@@ -49,19 +49,18 @@ const defaultFilter: UserDepositFilter = () => true;
 export function usePoolDepositFilterForPair(
   tokenPair: TokenPair | TokenIdPair | undefined
 ): (poolDeposit: DirectionalDepositRecord) => boolean {
-  const [tokenAddressA, tokenAddressB] = resolveTokenIdPair(tokenPair);
+  const [tokenIdA, tokenIdB] = resolveTokenIdPair(tokenPair);
   const poolDepositFilter = useCallback(
     (poolDeposit: DirectionalDepositRecord) => {
-      const addresses = [tokenAddressA, tokenAddressB];
       return (
-        !!tokenAddressA &&
-        !!tokenAddressB &&
+        !!tokenIdA &&
+        !!tokenIdB &&
         !!poolDeposit.pairID &&
-        addresses.includes(poolDeposit.pairID.token0) &&
-        addresses.includes(poolDeposit.pairID.token1)
+        [tokenIdA, tokenIdB].includes(poolDeposit.pairID.token0) &&
+        [tokenIdA, tokenIdB].includes(poolDeposit.pairID.token1)
       );
     },
-    [tokenAddressA, tokenAddressB]
+    [tokenIdA, tokenIdB]
   );
   return poolDepositFilter;
 }

--- a/src/lib/web3/hooks/useUserShares.ts
+++ b/src/lib/web3/hooks/useUserShares.ts
@@ -24,7 +24,7 @@ import {
   getTokenAddressPair,
 } from '../utils/tokens';
 import useTokens, {
-  matchTokenByAddress,
+  matchTokenByDenom,
   useTokensWithIbcInfo,
 } from './useTokens';
 import { StakeContext, UserStakedShare, useShares } from '../indexerProvider';
@@ -331,12 +331,8 @@ export function useUserPositionsContext(
               data?.poolReserves?.fee.toString() === deposit.fee.toString()
             );
           }) ?? undefined;
-        const token0 = allTokens.find(
-          matchTokenByAddress(deposit.pairID.token0)
-        );
-        const token1 = allTokens.find(
-          matchTokenByAddress(deposit.pairID.token1)
-        );
+        const token0 = allTokens.find(matchTokenByDenom(deposit.pairID.token0));
+        const token1 = allTokens.find(matchTokenByDenom(deposit.pairID.token1));
 
         if (token0 && token1) {
           // collect context of both side of the liquidity

--- a/src/lib/web3/hooks/useUserShares.ts
+++ b/src/lib/web3/hooks/useUserShares.ts
@@ -18,10 +18,10 @@ import { useRpcPromise } from '../rpcQueryClient';
 import { getPairID } from '../utils/pairs';
 import {
   Token,
-  TokenAddress,
-  TokenAddressPair,
+  TokenID,
+  TokenIdPair,
   TokenPair,
-  getTokenAddressPair,
+  resolveTokenIdPair,
 } from '../utils/tokens';
 import useTokens, {
   matchTokenByDenom,
@@ -47,9 +47,9 @@ export type UserDepositFilter = (
 const defaultFilter: UserDepositFilter = () => true;
 
 export function usePoolDepositFilterForPair(
-  tokenPair: TokenPair | TokenAddressPair | undefined
+  tokenPair: TokenPair | TokenIdPair | undefined
 ): (poolDeposit: DirectionalDepositRecord) => boolean {
-  const [tokenAddressA, tokenAddressB] = getTokenAddressPair(tokenPair);
+  const [tokenAddressA, tokenAddressB] = resolveTokenIdPair(tokenPair);
   const poolDepositFilter = useCallback(
     (poolDeposit: DirectionalDepositRecord) => {
       const addresses = [tokenAddressA, tokenAddressB];
@@ -259,7 +259,7 @@ export function useUserPositionsTotalReserves(
 export interface ShareValueContext {
   userShares: BigNumber;
   dexTotalShares: BigNumber;
-  token: TokenAddress;
+  token: TokenID;
   tickIndex1To0: BigNumber;
   dexTotalReserves: BigNumber;
   userReserves: BigNumber;

--- a/src/lib/web3/indexerProvider.tsx
+++ b/src/lib/web3/indexerProvider.tsx
@@ -16,7 +16,8 @@ import { useWeb3 } from './useWeb3';
 
 import { useRpcPromise } from './rpcQueryClient';
 import useTokens, {
-  matchTokenByAddress,
+  getTokenId,
+  matchTokenByDenom,
   useTokensWithIbcInfo,
 } from '../../lib/web3/hooks/useTokens';
 import useTokenPairs, { TokenPairReserves } from './hooks/useTokenPairs';
@@ -379,7 +380,7 @@ export function useBankBalances() {
   const balances = useMemo<TokenCoin[] | undefined>(() => {
     // check all known tokens with IBC context for matching balance denoms
     return data?.balances.reduce<TokenCoin[]>((result, balance) => {
-      const token = allTokensWithIBC.find(matchTokenByAddress(balance.denom));
+      const token = allTokensWithIBC.find(matchTokenByDenom(balance.denom));
       if (token) {
         result.push({ token, ...balance });
       }
@@ -415,12 +416,12 @@ export function useShares({
     return !staked ? shares : stakedShares;
 
     function tokensFilter(tokens: [tokenA: Token, tokenB: Token]) {
-      const [addressA, addressB] = tokens.map((token) => token.address);
+      const [denomA, denomB] = tokens.map((token) => getTokenId(token));
       return function tokenFilter({ pairId = '' }: IndexedShare): boolean {
-        const [address0, address1] = pairId.split('/');
+        const [denom0, denom1] = pairId.split('/');
         return (
-          (addressA === address0 && addressB === address1) ||
-          (addressA === address1 && addressB === address0)
+          (denomA === denom0 && denomB === denom1) ||
+          (denomA === denom1 && denomB === denom0)
         );
       };
     }

--- a/src/lib/web3/indexerProvider.tsx
+++ b/src/lib/web3/indexerProvider.tsx
@@ -16,7 +16,6 @@ import { useWeb3 } from './useWeb3';
 
 import { useRpcPromise } from './rpcQueryClient';
 import useTokens, {
-  getTokenId,
   matchTokenByDenom,
   useTokensWithIbcInfo,
 } from '../../lib/web3/hooks/useTokens';
@@ -24,7 +23,7 @@ import useTokenPairs, { TokenPairReserves } from './hooks/useTokenPairs';
 
 import { feeTypes } from './utils/fees';
 
-import { Token } from './utils/tokens';
+import { Token, getTokenId } from './utils/tokens';
 import { IndexedShare, getShareInfo } from './utils/shares';
 import { PairIdString, getPairID } from './utils/pairs';
 

--- a/src/lib/web3/utils/events.ts
+++ b/src/lib/web3/utils/events.ts
@@ -233,9 +233,7 @@ export function getSpentTokenAmount(
     (event): event is CoinSpentEvent =>
       !excludedEvents.includes(event) &&
       event.type === 'coin_spent' &&
-      (matchToken
-        ? event.attributes.amount.endsWith(matchToken.address)
-        : true) &&
+      (matchToken ? event.attributes.amount.endsWith(matchToken.base) : true) &&
       (spender ? event.attributes.spender === spender : true)
   );
   return sumTokenEventAmounts(tokenEvents);
@@ -256,9 +254,7 @@ export function getReceivedTokenAmount(
     (event): event is CoinReceivedEvent =>
       !excludedEvents.includes(event) &&
       event.type === 'coin_received' &&
-      (matchToken
-        ? event.attributes.amount.endsWith(matchToken.address)
-        : true) &&
+      (matchToken ? event.attributes.amount.endsWith(matchToken.base) : true) &&
       (receiver ? event.attributes.receiver === receiver : true)
   );
   return sumTokenEventAmounts(tokenEvents);

--- a/src/lib/web3/utils/events.ts
+++ b/src/lib/web3/utils/events.ts
@@ -3,7 +3,7 @@ import { Event, parseCoins } from '@cosmjs/stargate';
 
 import { tickIndexToPrice } from './ticks';
 import { WalletAddress } from './address';
-import { Token } from './tokens';
+import { Token, TokenID, getTokenId } from './tokens';
 
 export function mapEventAttributes<T = ChainEvent>(event: Event): T {
   return {
@@ -223,8 +223,14 @@ export function getSpentTokenAmount(
   {
     address: spender,
     matchToken,
+    matchTokenId = getTokenId(matchToken),
     includeFees,
-  }: { address?: WalletAddress; matchToken?: Token; includeFees?: boolean } = {}
+  }: {
+    address?: WalletAddress;
+    matchToken?: Token;
+    matchTokenId?: TokenID;
+    includeFees?: boolean;
+  } = {}
 ): BigNumber {
   const excludedEvents: ChainEvent[] = includeFees
     ? []
@@ -233,7 +239,7 @@ export function getSpentTokenAmount(
     (event): event is CoinSpentEvent =>
       !excludedEvents.includes(event) &&
       event.type === 'coin_spent' &&
-      (matchToken ? event.attributes.amount.endsWith(matchToken.base) : true) &&
+      (matchTokenId ? event.attributes.amount.endsWith(matchTokenId) : true) &&
       (spender ? event.attributes.spender === spender : true)
   );
   return sumTokenEventAmounts(tokenEvents);
@@ -244,8 +250,14 @@ export function getReceivedTokenAmount(
   {
     address: receiver,
     matchToken,
+    matchTokenId = getTokenId(matchToken),
     includeFees,
-  }: { address?: WalletAddress; matchToken?: Token; includeFees?: boolean } = {}
+  }: {
+    address?: WalletAddress;
+    matchToken?: Token;
+    matchTokenId?: TokenID;
+    includeFees?: boolean;
+  } = {}
 ): BigNumber {
   const excludedEvents: ChainEvent[] = includeFees
     ? []
@@ -254,7 +266,7 @@ export function getReceivedTokenAmount(
     (event): event is CoinReceivedEvent =>
       !excludedEvents.includes(event) &&
       event.type === 'coin_received' &&
-      (matchToken ? event.attributes.amount.endsWith(matchToken.base) : true) &&
+      (matchTokenId ? event.attributes.amount.endsWith(matchTokenId) : true) &&
       (receiver ? event.attributes.receiver === receiver : true)
   );
   return sumTokenEventAmounts(tokenEvents);

--- a/src/lib/web3/utils/events.ts
+++ b/src/lib/web3/utils/events.ts
@@ -211,8 +211,8 @@ export function getLastPrice(
   const tickIndex = lastTickUpdate
     ? new BigNumber(lastTickUpdate.attributes.TickIndex)
     : undefined;
-  const forward = lastTickUpdate?.attributes.Token0 === tokenA.address;
-  const reverse = lastTickUpdate?.attributes.Token0 === tokenB.address;
+  const forward = lastTickUpdate?.attributes.Token0 === getTokenId(tokenA);
+  const reverse = lastTickUpdate?.attributes.Token0 === getTokenId(tokenB);
   return tickIndex && (forward || reverse)
     ? tickIndexToPrice(forward ? tickIndex : tickIndex.negated())
     : undefined;

--- a/src/lib/web3/utils/pairs.ts
+++ b/src/lib/web3/utils/pairs.ts
@@ -1,10 +1,5 @@
 import { TickInfo } from './ticks';
-import {
-  TokenAddress,
-  TokenAddressPair,
-  TokenPair,
-  getTokenAddressPair,
-} from './tokens';
+import { TokenID, TokenIdPair, TokenPair, resolveTokenIdPair } from './tokens';
 
 export interface PairInfo {
   token0: string;
@@ -26,15 +21,15 @@ export type PairIdString = string;
  * @returns pair id for tokens
  */
 export function getPairID(
-  token0: TokenAddress = '',
-  token1: TokenAddress = ''
+  token0: TokenID = '',
+  token1: TokenID = ''
 ): PairIdString {
   return token0 && token1 ? `${token0}<>${token1}` : '';
 }
 export function getTokenAddressPairID(
-  tokenPair: TokenPair | TokenAddressPair
+  tokenPair: TokenPair | TokenIdPair
 ): PairIdString {
-  const tokenAddressPair = getTokenAddressPair(tokenPair);
+  const tokenAddressPair = resolveTokenIdPair(tokenPair);
   return getPairID(...tokenAddressPair);
 }
 

--- a/src/lib/web3/utils/pairs.ts
+++ b/src/lib/web3/utils/pairs.ts
@@ -22,8 +22,8 @@ export type PairIdString = string;
 
 /**
  * Gets the pair id for a sorted pair of tokens
- * @param token0 address of token 0
- * @param token1 address of token 1
+ * @param token0 ID of token 0
+ * @param token1 ID of token 1
  * @returns pair id for tokens
  */
 export function getPairID(
@@ -42,8 +42,8 @@ export function getTokenPairID(
 /**
  * Check if the current TokenA/TokenB pair is in the same order as Token0/1
  * @param pairID pair id for tokens
- * @param tokenA address of token A
- * @param tokenB address of token B
+ * @param tokenA ID of token A
+ * @param tokenB ID of token B
  * @returns bool for inverted order
  */
 export function hasInvertedOrder(
@@ -57,7 +57,7 @@ export function guessInvertedOrder(
   tokens: TokenPair | TokenIdPair
 ): boolean | undefined {
   // assume that Array.sort is equivalent to the sorting function in Golang
-  // for all known token address values
+  // for all known token ID values
   const tokenPairID = getPairID(...tokens.map(resolveTokenId).sort());
   return tokens[0] && tokens[1]
     ? hasInvertedOrder(tokenPairID, tokens)
@@ -68,8 +68,8 @@ export function guessInvertedOrder(
  * Checks given token pair against stored data to determine
  * if the current TokenA/TokenB pair exists and is in the same order as Token0/1
  * @param pairMap pair map of stored tokens
- * @param tokenA address of token A
- * @param tokenB address of token B
+ * @param tokenA ID of token A
+ * @param tokenB ID of token B
  * @returns [isSorted, isInverseSorted] array for determining sort order (both may be `false` if pair is not found)
  */
 export function hasMatchingPairOfOrder(

--- a/src/lib/web3/utils/pairs.ts
+++ b/src/lib/web3/utils/pairs.ts
@@ -1,5 +1,11 @@
 import { TickInfo } from './ticks';
-import { TokenID, TokenIdPair, TokenPair, resolveTokenIdPair } from './tokens';
+import {
+  TokenID,
+  TokenIdPair,
+  TokenPair,
+  resolveTokenId,
+  resolveTokenIdPair,
+} from './tokens';
 
 export interface PairInfo {
   token0: string;
@@ -26,11 +32,11 @@ export function getPairID(
 ): PairIdString {
   return token0 && token1 ? `${token0}<>${token1}` : '';
 }
-export function getTokenAddressPairID(
+export function getTokenPairID(
   tokenPair: TokenPair | TokenIdPair
 ): PairIdString {
-  const tokenAddressPair = resolveTokenIdPair(tokenPair);
-  return getPairID(...tokenAddressPair);
+  const tokenIdPair = resolveTokenIdPair(tokenPair);
+  return getPairID(...tokenIdPair);
 }
 
 /**
@@ -42,21 +48,19 @@ export function getTokenAddressPairID(
  */
 export function hasInvertedOrder(
   pairID: string,
-  tokenA: string,
-  tokenB: string
+  tokenPair: TokenPair | TokenIdPair
 ): boolean {
-  return getPairID(tokenA, tokenB) !== pairID;
+  return getTokenPairID(tokenPair) !== pairID;
 }
 
 export function guessInvertedOrder(
-  tokenA?: string,
-  tokenB?: string
+  tokens: TokenPair | TokenIdPair
 ): boolean | undefined {
   // assume that Array.sort is equivalent to the sorting function in Golang
   // for all known token address values
-  const pairID = getPairID(...[tokenA, tokenB].sort());
-  return tokenA && tokenB
-    ? hasInvertedOrder(pairID, tokenA, tokenB)
+  const tokenPairID = getPairID(...tokens.map(resolveTokenId).sort());
+  return tokens[0] && tokens[1]
+    ? hasInvertedOrder(tokenPairID, tokens)
     : undefined;
 }
 

--- a/src/lib/web3/utils/shares.ts
+++ b/src/lib/web3/utils/shares.ts
@@ -32,12 +32,12 @@ export function getShareDenom(
   tickIndex1To0: number,
   fee: number
 ): string | undefined {
-  const tokenAddresses = resolveTokenIdPair(tokens);
-  const [token0Address, token1Address] = guessInvertedOrder(tokens)
-    ? [tokenAddresses[1], tokenAddresses[0]]
-    : tokenAddresses;
-  if (token0Address && token1Address && !isNaN(tickIndex1To0) && !isNaN(fee)) {
-    return `DualityPoolShares-${token0Address}-${token1Address}-t${tickIndex1To0.toFixed(
+  const tokenIds = resolveTokenIdPair(tokens);
+  const [tokenId0, tokenId1] = guessInvertedOrder(tokens)
+    ? [tokenIds[1], tokenIds[0]]
+    : tokenIds;
+  if (tokenId0 && tokenId1 && !isNaN(tickIndex1To0) && !isNaN(fee)) {
+    return `DualityPoolShares-${tokenId0}-${tokenId1}-t${tickIndex1To0.toFixed(
       0
     )}-f${fee.toFixed(0)}`;
   }

--- a/src/lib/web3/utils/shares.ts
+++ b/src/lib/web3/utils/shares.ts
@@ -1,5 +1,5 @@
 import { Coin } from '@duality-labs/dualityjs/types/codegen/cosmos/base/v1beta1/coin';
-import { TokenAddressPair, TokenPair, getTokenAddressPair } from './tokens';
+import { TokenIdPair, TokenPair, resolveTokenIdPair } from './tokens';
 import { guessInvertedOrder } from './pairs';
 
 export interface IndexedShare {
@@ -28,11 +28,11 @@ export function getShareInfo(coin: Coin) {
 }
 
 export function getShareDenom(
-  tokens: TokenPair | TokenAddressPair,
+  tokens: TokenPair | TokenIdPair,
   tickIndex1To0: number,
   fee: number
 ): string | undefined {
-  const tokenAddresses = getTokenAddressPair(tokens);
+  const tokenAddresses = resolveTokenIdPair(tokens);
   const [token0Address, token1Address] = guessInvertedOrder(
     tokenAddresses[0],
     tokenAddresses[1]

--- a/src/lib/web3/utils/shares.ts
+++ b/src/lib/web3/utils/shares.ts
@@ -33,10 +33,7 @@ export function getShareDenom(
   fee: number
 ): string | undefined {
   const tokenAddresses = resolveTokenIdPair(tokens);
-  const [token0Address, token1Address] = guessInvertedOrder(
-    tokenAddresses[0],
-    tokenAddresses[1]
-  )
+  const [token0Address, token1Address] = guessInvertedOrder(tokens)
     ? [tokenAddresses[1], tokenAddresses[0]]
     : tokenAddresses;
   if (token0Address && token1Address && !isNaN(tickIndex1To0) && !isNaN(fee)) {

--- a/src/lib/web3/utils/tokens.ts
+++ b/src/lib/web3/utils/tokens.ts
@@ -8,23 +8,22 @@ export interface Token extends Asset {
   chain: Chain;
 }
 
-// todo: fix all usage of TokenAddress to TokenID
-export type TokenAddress = string; // a valid hex address, eg. 0x01
+export type TokenID = string; // a valid token identifier, eg. token or ibc/3C3D7B3BE4ECC85A0E5B52A3AEC3B7DFC2AA9CA47C37821E57020D6807043BE9
 
 export type TokenPair = [Token, Token];
-export type TokenAddressPair = [TokenAddress, TokenAddress];
-export function getTokenAddress(
-  token: Token | TokenAddress | undefined
-): TokenAddress | undefined {
+export type TokenIdPair = [TokenID, TokenID];
+function resolveTokenId(
+  token: Token | TokenID | undefined
+): TokenID | undefined {
   return typeof token === 'string' ? token : getTokenId(token);
 }
-export function getTokenAddressPair(
-  [token0, token1]: TokenPair | TokenAddressPair | [undefined, undefined] = [
+export function resolveTokenIdPair(
+  [token0, token1]: TokenPair | TokenIdPair | [undefined, undefined] = [
     undefined,
     undefined,
   ]
-): [TokenAddress | undefined, TokenAddress | undefined] {
-  return [getTokenAddress(token0), getTokenAddress(token1)];
+): [TokenID | undefined, TokenID | undefined] {
+  return [resolveTokenId(token0), resolveTokenId(token1)];
 }
 
 export function getDenomAmount(

--- a/src/lib/web3/utils/tokens.ts
+++ b/src/lib/web3/utils/tokens.ts
@@ -1,14 +1,14 @@
 import BigNumber from 'bignumber.js';
 import { Asset, Chain } from '@chain-registry/types';
 import { sha256 } from '@cosmjs/crypto';
+import { getTokenId } from '../hooks/useTokens';
 
 export interface Token extends Asset {
   // each asset should have exactly one chain parent
   chain: Chain;
-  // enforce that an address exists
-  address: TokenAddress;
 }
 
+// todo: fix all usage of TokenAddress to TokenID
 export type TokenAddress = string; // a valid hex address, eg. 0x01
 
 export type TokenPair = [Token, Token];
@@ -16,7 +16,7 @@ export type TokenAddressPair = [TokenAddress, TokenAddress];
 export function getTokenAddress(
   token: Token | TokenAddress | undefined
 ): TokenAddress | undefined {
-  return typeof token === 'string' ? token : token?.address;
+  return typeof token === 'string' ? token : getTokenId(token);
 }
 export function getTokenAddressPair(
   [token0, token1]: TokenPair | TokenAddressPair | [undefined, undefined] = [

--- a/src/lib/web3/utils/tokens.ts
+++ b/src/lib/web3/utils/tokens.ts
@@ -47,10 +47,6 @@ export function getTokenId(token: Token | undefined): string | undefined {
   if (token?.ibc) {
     return getIbcBaseDenom(token);
   } else if (token?.chain.chain_id === REACT_APP__CHAIN_ID) {
-    // allow dev assets to be identified by address and represented denom
-    if (token.type_asset === '___dev___') {
-      return token.address;
-    }
     return token?.base;
   }
 }

--- a/src/lib/web3/utils/tokens.ts
+++ b/src/lib/web3/utils/tokens.ts
@@ -47,6 +47,10 @@ export function getTokenId(token: Token | undefined): string | undefined {
   if (token?.ibc) {
     return getIbcBaseDenom(token);
   } else if (token?.chain.chain_id === REACT_APP__CHAIN_ID) {
+    // allow dev assets to be identified by address and represented denom
+    if (token.type_asset === '___dev___') {
+      return token.address;
+    }
     return token?.base;
   }
 }

--- a/src/lib/web3/utils/tokens.ts
+++ b/src/lib/web3/utils/tokens.ts
@@ -12,7 +12,7 @@ export type TokenID = string; // a valid token identifier, eg. token or ibc/3C3D
 
 export type TokenPair = [Token, Token];
 export type TokenIdPair = [TokenID, TokenID];
-function resolveTokenId(
+export function resolveTokenId(
   token: Token | TokenID | undefined
 ): TokenID | undefined {
   return typeof token === 'string' ? token : getTokenId(token);

--- a/src/lib/web3/utils/tokens.ts
+++ b/src/lib/web3/utils/tokens.ts
@@ -3,6 +3,7 @@ import { Asset, Chain } from '@chain-registry/types';
 import { sha256 } from '@cosmjs/crypto';
 
 export interface Token extends Asset {
+  // each asset should have exactly one chain parent
   chain: Chain;
   // enforce that an address exists
   address: TokenAddress;

--- a/src/pages/Orderbook/OrderbookChart.tsx
+++ b/src/pages/Orderbook/OrderbookChart.tsx
@@ -16,7 +16,8 @@ import {
 import { Token } from '../../lib/web3/utils/tokens';
 
 import useTokens, {
-  matchTokenByAddress,
+  getTokenId,
+  matchTokenByDenom,
   useTokensWithIbcInfo,
 } from '../../lib/web3/hooks/useTokens';
 import useTokenPairs from '../../lib/web3/hooks/useTokenPairs';
@@ -69,8 +70,8 @@ export default function OrderBookChart({
   tokenA: Token;
   tokenB: Token;
 }) {
-  const tokenAPath = tokenA.address;
-  const tokenBPath = tokenB.address;
+  const tokenIdA = getTokenId(tokenA);
+  const tokenIdB = getTokenId(tokenB);
 
   const navigate = useNavigate();
 
@@ -88,8 +89,8 @@ export default function OrderBookChart({
             // find the tokens that match our known pair token addresses
             .map(([token0, token1]) => {
               return [
-                tokenList.find(matchTokenByAddress(token0)),
-                tokenList.find(matchTokenByAddress(token1)),
+                tokenList.find(matchTokenByDenom(token0)),
+                tokenList.find(matchTokenByDenom(token1)),
               ];
             })
             // remove pairs with unfound tokens
@@ -162,7 +163,7 @@ export default function OrderBookChart({
     };
 
     // don't create options unless ID requirements are satisfied
-    if (chartRef.current && tokenPairID && tokenAPath && tokenBPath) {
+    if (chartRef.current && tokenPairID && tokenIdA && tokenIdB) {
       const datafeed: IBasicDataFeed = {
         onReady: async (onReadyCallback) => {
           await new Promise((resolve) => setTimeout(resolve, 1));
@@ -255,7 +256,7 @@ export default function OrderBookChart({
         ) => {
           // construct fetch ID that corresponds to a unique known fetch height
           const fetchID = getFetchID(symbolInfo, resolution);
-          const url = getFetchURL(tokenAPath, tokenBPath, resolution, {
+          const url = getFetchURL(tokenIdA, tokenIdB, resolution, {
             'pagination.before': periodParams.to?.toFixed(0),
             'pagination.after': periodParams.from?.toFixed(0),
           });
@@ -292,7 +293,7 @@ export default function OrderBookChart({
           onResetCacheNeededCallback
         ) => {
           const fetchID = getFetchID(symbolInfo, resolution);
-          const url = getFetchURL(tokenAPath, tokenBPath, resolution, {
+          const url = getFetchURL(tokenIdA, tokenIdB, resolution, {
             'block_range.from_height': knownHeights.get(fetchID)?.toFixed(0),
           });
 
@@ -343,7 +344,7 @@ export default function OrderBookChart({
         });
       };
     }
-  }, [navigate, tokenAPath, tokenBPath, tokenPairID, tokenPairs]);
+  }, [navigate, tokenIdA, tokenIdB, tokenPairID, tokenPairs]);
 
   return <div className="trading-view-chart flex" ref={chartRef}></div>;
 }

--- a/src/pages/Orderbook/OrderbookChart.tsx
+++ b/src/pages/Orderbook/OrderbookChart.tsx
@@ -13,10 +13,9 @@ import {
   Bar,
 } from '@tradingview/charting-library';
 
-import { Token } from '../../lib/web3/utils/tokens';
+import { Token, getTokenId } from '../../lib/web3/utils/tokens';
 
 import useTokens, {
-  getTokenId,
   matchTokenByDenom,
   useTokensWithIbcInfo,
 } from '../../lib/web3/hooks/useTokens';

--- a/src/pages/Orderbook/OrderbookChart.tsx
+++ b/src/pages/Orderbook/OrderbookChart.tsx
@@ -78,18 +78,18 @@ export default function OrderBookChart({
   const chartRef = useRef<HTMLDivElement>(null);
 
   const tokenList = useTokensWithIbcInfo(useTokens());
-  const { data: tokenPairAddresses } = useTokenPairs();
+  const { data: tokenPairReserves } = useTokenPairs();
 
   // memoize tokenPairs so we don't trigger the graph re-rendering too often
   const tokenPairs = useDeepCompareMemoize(
     useMemo<Array<[Token, Token]>>(() => {
-      return tokenPairAddresses
-        ? tokenPairAddresses
-            // find the tokens that match our known pair token addresses
-            .map(([token0, token1]) => {
+      return tokenPairReserves
+        ? tokenPairReserves
+            // find the tokens that match our known pair token IDs
+            .map(([tokenId0, tokenId1]) => {
               return [
-                tokenList.find(matchTokenByDenom(token0)),
-                tokenList.find(matchTokenByDenom(token1)),
+                tokenList.find(matchTokenByDenom(tokenId0)),
+                tokenList.find(matchTokenByDenom(tokenId1)),
               ];
             })
             // remove pairs with unfound tokens
@@ -97,7 +97,7 @@ export default function OrderBookChart({
               tokenPair.every(Boolean)
             )
         : [];
-    }, [tokenList, tokenPairAddresses])
+    }, [tokenList, tokenPairReserves])
   );
 
   // tokenPairID is made of symbols, which is different to token paths

--- a/src/pages/Orderbook/OrderbookFooter.tsx
+++ b/src/pages/Orderbook/OrderbookFooter.tsx
@@ -14,7 +14,11 @@ import {
   getSpentTokenAmount,
   mapEventAttributes,
 } from '../../lib/web3/utils/events';
-import { Token, getDisplayDenomAmount } from '../../lib/web3/utils/tokens';
+import {
+  Token,
+  getDisplayDenomAmount,
+  getTokenId,
+} from '../../lib/web3/utils/tokens';
 import {
   formatAmount,
   formatCurrency,
@@ -145,7 +149,7 @@ function SideColumn({
     return (
       <td>
         {tokenA && tokenB ? (
-          attributes.TokenIn === tokenA.address ? (
+          attributes.TokenIn === getTokenId(tokenA) ? (
             <span className="text-success">Buy</span>
           ) : (
             <span className="text-danger">Sell</span>
@@ -194,7 +198,7 @@ function AmountColumn({
     tokenA &&
     tokenB &&
     attributes &&
-    (attributes.TokenIn === tokenA.address ? tokenA : tokenB);
+    (attributes.TokenIn === getTokenId(tokenA) ? tokenA : tokenB);
   const reservesIn =
     tokenIn && getDisplayDenomReserves(tokenIn, events, attributes);
   return (
@@ -215,7 +219,7 @@ function FilledColumn({
   const attributes = getPlaceLimitOrderActionEvent(tx);
   const [tokenIn] =
     tokenA && tokenB && attributes
-      ? attributes.TokenIn === tokenA.address
+      ? attributes.TokenIn === getTokenId(tokenA)
         ? [tokenA, tokenB]
         : [tokenB, tokenA]
       : [];
@@ -250,7 +254,7 @@ function TotalColumn({
     tokenA &&
     tokenB &&
     attributes &&
-    (attributes.TokenIn === tokenA.address
+    (attributes.TokenIn === getTokenId(tokenA)
       ? new BigNumber(
           getDisplayDenomReserves(tokenA, events, attributes) || 0
         ).multipliedBy(tokenAPrice || 0)
@@ -284,9 +288,10 @@ function getTokenReserves(
   attributes: DexPlaceLimitOrderEvent['attributes']
 ) {
   const address = attributes.Creator;
-  return attributes.TokenIn === token.address
-    ? getSpentTokenAmount(events, { address, matchToken: token })
-    : getReceivedTokenAmount(events, { address, matchToken: token });
+  const tokenId = getTokenId(token);
+  return attributes.TokenIn === tokenId
+    ? getSpentTokenAmount(events, { address, matchTokenId: tokenId })
+    : getReceivedTokenAmount(events, { address, matchTokenId: tokenId });
 }
 
 function getPlaceLimitOrderActionEvent(tx: Tx) {

--- a/src/pages/Orderbook/OrderbookList.tsx
+++ b/src/pages/Orderbook/OrderbookList.tsx
@@ -10,7 +10,7 @@ import {
 import { useTokenPairTickLiquidity } from '../../lib/web3/hooks/useTickLiquidity';
 import { useOrderedTokenPair } from '../../lib/web3/hooks/useTokenPairs';
 import { useSimplePrice } from '../../lib/tokenPrices';
-import { Token, getTokenValue } from '../../lib/web3/utils/tokens';
+import { Token, getTokenId, getTokenValue } from '../../lib/web3/utils/tokens';
 import { TickInfo, priceToTickIndex } from '../../lib/web3/utils/ticks';
 
 import './OrderbookList.scss';
@@ -26,18 +26,18 @@ export default function OrderBookList({
   tokenA: Token;
   tokenB: Token;
 }) {
-  const [token0Address, token1Address] =
-    useOrderedTokenPair([tokenA.address, tokenB.address]) || [];
+  const [tokenIdA, tokenIdB] = [getTokenId(tokenA), getTokenId(tokenB)];
+  const [tokenId0, tokenId1] = useOrderedTokenPair([tokenIdA, tokenIdB]) || [];
   const {
     data: [token0Ticks = [], token1Ticks = []],
-  } = useTokenPairTickLiquidity([token0Address, token1Address]);
+  } = useTokenPairTickLiquidity([tokenId0, tokenId1]);
 
   const [forward, reverse] = [
-    token0Address === tokenA.address && token1Address === tokenB.address,
-    token1Address === tokenA.address && token0Address === tokenB.address,
+    tokenId0 === tokenIdA && tokenId1 === tokenIdB,
+    tokenId1 === tokenIdA && tokenId0 === tokenIdB,
   ];
 
-  const currentPrice = useCurrentPriceFromTicks(tokenA.address, tokenB.address);
+  const currentPrice = useCurrentPriceFromTicks(tokenIdA, tokenIdB);
   const resolutionPercent = 0.01; // size of price steps
 
   // todo: this needs fixes, the comparison between prices is off because it

--- a/src/pages/Orderbook/OrderbookTradesList.tsx
+++ b/src/pages/Orderbook/OrderbookTradesList.tsx
@@ -7,7 +7,7 @@ import useTransactionTableData, {
 import { useCurrentPriceFromTicks } from '../../components/Liquidity/useCurrentPriceFromTicks';
 import { formatAmount, getDecimalPlaces } from '../../lib/utils/number';
 import { useSimplePrice } from '../../lib/tokenPrices';
-import { Token, getTokenValue } from '../../lib/web3/utils/tokens';
+import { Token, getTokenId, getTokenValue } from '../../lib/web3/utils/tokens';
 
 import {
   getLastPrice,
@@ -61,7 +61,10 @@ export default function OrderBookTradesList({
     }
   }, [data]);
 
-  const currentPrice = useCurrentPriceFromTicks(tokenA.address, tokenB.address);
+  const currentPrice = useCurrentPriceFromTicks(
+    getTokenId(tokenA),
+    getTokenId(tokenB)
+  );
 
   const priceDecimalPlaces =
     currentPrice !== undefined

--- a/src/pages/Pool/MyPositionTableCard.tsx
+++ b/src/pages/Pool/MyPositionTableCard.tsx
@@ -12,7 +12,7 @@ import { Token, getDisplayDenomAmount } from '../../lib/web3/utils/tokens';
 import { EditedPosition } from '../MyLiquidity/useEditLiquidity';
 import { guessInvertedOrder } from '../../lib/web3/utils/pairs';
 import { useSimplePrice } from '../../lib/tokenPrices';
-import { getTokenId, matchTokens } from '../../lib/web3/hooks/useTokens';
+import { matchTokens } from '../../lib/web3/hooks/useTokens';
 import { useStake } from '../MyLiquidity/useStaking';
 
 import TableCard from '../../components/cards/TableCard';
@@ -237,10 +237,8 @@ export function MyEditedPositionTableCard({
   viewableMaxIndex: number | undefined;
   edgePriceIndex: number | undefined;
 }) {
-  const invertedTokenOrder = guessInvertedOrder(
-    getTokenId(tokenA),
-    getTokenId(tokenB)
-  );
+  const invertedTokenOrder =
+    !!tokenA && !!tokenB && guessInvertedOrder([tokenA, tokenB]);
 
   const {
     data: [priceA, priceB],

--- a/src/pages/Pool/MyPositionTableCard.tsx
+++ b/src/pages/Pool/MyPositionTableCard.tsx
@@ -12,7 +12,7 @@ import { Token, getDisplayDenomAmount } from '../../lib/web3/utils/tokens';
 import { EditedPosition } from '../MyLiquidity/useEditLiquidity';
 import { guessInvertedOrder } from '../../lib/web3/utils/pairs';
 import { useSimplePrice } from '../../lib/tokenPrices';
-import { matchTokens } from '../../lib/web3/hooks/useTokens';
+import { getTokenId, matchTokens } from '../../lib/web3/hooks/useTokens';
 import { useStake } from '../MyLiquidity/useStaking';
 
 import TableCard from '../../components/cards/TableCard';
@@ -237,7 +237,10 @@ export function MyEditedPositionTableCard({
   viewableMaxIndex: number | undefined;
   edgePriceIndex: number | undefined;
 }) {
-  const invertedTokenOrder = guessInvertedOrder(tokenA.address, tokenB.address);
+  const invertedTokenOrder = guessInvertedOrder(
+    getTokenId(tokenA),
+    getTokenId(tokenB)
+  );
 
   const {
     data: [priceA, priceB],

--- a/src/pages/Pool/PoolManagement.tsx
+++ b/src/pages/Pool/PoolManagement.tsx
@@ -38,7 +38,7 @@ import {
   MyNewPositionTableCard,
 } from './MyPositionTableCard';
 
-import { useTokenPathPart } from '../../lib/web3/hooks/useTokens';
+import { getTokenId, useTokenPathPart } from '../../lib/web3/hooks/useTokens';
 import { useDeposit } from './useDeposit';
 import useFeeLiquidityMap from './useFeeLiquidityMap';
 
@@ -198,8 +198,8 @@ export default function PoolManagement({
     !!tokenA && !!tokenB && values.some((v) => Number(v) >= 0);
 
   const currentPriceIndexFromTicks = useCurrentPriceIndexFromTicks(
-    tokenA?.address,
-    tokenB?.address
+    getTokenId(tokenA),
+    getTokenId(tokenB)
   );
 
   const [initialPrice, setInitialPrice] = useState<string>('');
@@ -792,8 +792,8 @@ export default function PoolManagement({
     (balanceTokenB && new BigNumber(balanceTokenB).gte(values[1])) || false;
 
   const { data: feeLiquidityMap } = useFeeLiquidityMap(
-    tokenA?.address,
-    tokenB?.address
+    getTokenId(tokenA),
+    getTokenId(tokenB)
   );
 
   const pairPoolDepositFilter = usePoolDepositFilterForPair(
@@ -812,8 +812,8 @@ export default function PoolManagement({
     useEditLiquidity();
 
   const invertedTokenOrder = guessInvertedOrder(
-    tokenA?.address ?? '',
-    tokenB?.address ?? ''
+    getTokenId(tokenA) ?? '',
+    getTokenId(tokenB) ?? ''
   );
 
   const [[viewableMinIndex, viewableMaxIndex] = [], setViewableIndexes] =

--- a/src/pages/Pool/PoolManagement.tsx
+++ b/src/pages/Pool/PoolManagement.tsx
@@ -38,7 +38,7 @@ import {
   MyNewPositionTableCard,
 } from './MyPositionTableCard';
 
-import { getTokenId, useTokenPathPart } from '../../lib/web3/hooks/useTokens';
+import { useTokenPathPart } from '../../lib/web3/hooks/useTokens';
 import { useDeposit } from './useDeposit';
 import useFeeLiquidityMap from './useFeeLiquidityMap';
 
@@ -59,6 +59,7 @@ import {
   Token,
   getBaseDenomAmount,
   getDisplayDenomAmount,
+  getTokenId,
   roundToBaseUnit,
 } from '../../lib/web3/utils/tokens';
 

--- a/src/pages/Pool/PoolManagement.tsx
+++ b/src/pages/Pool/PoolManagement.tsx
@@ -811,10 +811,8 @@ export default function PoolManagement({
   const [{ isValidating: isValidatingEdit }, sendEditRequest] =
     useEditLiquidity();
 
-  const invertedTokenOrder = guessInvertedOrder(
-    getTokenId(tokenA) ?? '',
-    getTokenId(tokenB) ?? ''
-  );
+  const invertedTokenOrder =
+    !!tokenA && !!tokenB && guessInvertedOrder([tokenA, tokenB]);
 
   const [[viewableMinIndex, viewableMaxIndex] = [], setViewableIndexes] =
     useState<[number, number] | undefined>();

--- a/src/pages/Pool/PoolOverview.tsx
+++ b/src/pages/Pool/PoolOverview.tsx
@@ -739,15 +739,15 @@ function SwapColumn({
     function getTokenAReserves() {
       const address = attributes.Creator;
       return attributes.TokenIn === tokenIdA
-        ? getSpentTokenAmount(events, { address, matchToken: tokenA })
-        : getReceivedTokenAmount(events, { address, matchToken: tokenA });
+        ? getSpentTokenAmount(events, { address, matchTokenId: tokenIdA })
+        : getReceivedTokenAmount(events, { address, matchTokenId: tokenIdA });
     }
 
     function getTokenBReserves() {
       const address = attributes.Creator;
       return attributes.TokenIn === tokenIdB
-        ? getSpentTokenAmount(events, { address, matchToken: tokenB })
-        : getReceivedTokenAmount(events, { address, matchToken: tokenB });
+        ? getSpentTokenAmount(events, { address, matchTokenId: tokenIdB })
+        : getReceivedTokenAmount(events, { address, matchTokenId: tokenIdB });
     }
 
     function getTokenReservesInDenom(token: Token, reserves: BigNumber.Value) {

--- a/src/pages/Pool/PoolOverview.tsx
+++ b/src/pages/Pool/PoolOverview.tsx
@@ -592,11 +592,7 @@ function EventColumn<
     return null;
 
     function getHasInvertedOrder(): boolean {
-      return hasInvertedOrder(
-        getPairID(Token0, Token1),
-        tokenA.base,
-        tokenB.base
-      );
+      return hasInvertedOrder(getPairID(Token0, Token1), [tokenA, tokenB]);
     }
 
     function getTokenAReserves() {

--- a/src/pages/Pool/PoolOverview.tsx
+++ b/src/pages/Pool/PoolOverview.tsx
@@ -12,7 +12,11 @@ import { SmallCardRow } from '../../components/cards/SmallCard';
 import StatCardTVL from '../../components/stats/StatCardTVL';
 
 import { formatAddress } from '../../lib/web3/utils/address';
-import { Token, getDisplayDenomAmount } from '../../lib/web3/utils/tokens';
+import {
+  Token,
+  getDisplayDenomAmount,
+  getTokenId,
+} from '../../lib/web3/utils/tokens';
 import { getPairID, hasInvertedOrder } from '../../lib/web3/utils/pairs';
 import {
   ChainEvent,
@@ -37,7 +41,6 @@ import { formatRelativeTime } from '../../lib/utils/time';
 
 import './Pool.scss';
 import useTokens, {
-  getTokenId,
   matchTokenByDenom,
   useTokenPathPart,
   useTokenValue,

--- a/src/pages/Pool/PoolOverview.tsx
+++ b/src/pages/Pool/PoolOverview.tsx
@@ -37,7 +37,8 @@ import { formatRelativeTime } from '../../lib/utils/time';
 
 import './Pool.scss';
 import useTokens, {
-  matchTokenByAddress,
+  getTokenId,
+  matchTokenByDenom,
   useTokenPathPart,
   useTokenValue,
 } from '../../lib/web3/hooks/useTokens';
@@ -207,7 +208,7 @@ function Incentives({ tokenA, tokenB }: { tokenA?: Token; tokenB?: Token }) {
 
   const { data: { gauges } = {} } = useIncentiveGauges();
   const filteredGauges = useMemo(() => {
-    const tokenAddresses = [tokenA?.address, tokenB?.address].filter(
+    const tokenAddresses = [getTokenId(tokenA), getTokenId(tokenB)].filter(
       (address): address is string => !!address
     );
     return tokenAddresses.length > 0
@@ -234,7 +235,7 @@ function Incentives({ tokenA, tokenB }: { tokenA?: Token; tokenB?: Token }) {
             >
               <div className="row gap-4">
                 {row.coins.map((coin) => {
-                  const token = tokens.find(matchTokenByAddress(coin.denom));
+                  const token = tokens.find(matchTokenByDenom(coin.denom));
                   return token ? (
                     <div
                       key={coin.denom}
@@ -256,10 +257,10 @@ function Incentives({ tokenA, tokenB }: { tokenA?: Token; tokenB?: Token }) {
         function TokenCellRange({ row }: { row: Gauge }) {
           if (row.distribute_to?.pairID) {
             const Token0 = tokens.find(
-              matchTokenByAddress(row.distribute_to.pairID.token0)
+              matchTokenByDenom(row.distribute_to.pairID.token0)
             );
             const Token1 = tokens.find(
-              matchTokenByAddress(row.distribute_to.pairID.token1)
+              matchTokenByDenom(row.distribute_to.pairID.token1)
             );
             return (
               <td>
@@ -295,7 +296,7 @@ function Incentives({ tokenA, tokenB }: { tokenA?: Token; tokenB?: Token }) {
           return (
             <td>
               {row.coins.map((coin) => {
-                const token = tokens.find(matchTokenByAddress(coin.denom));
+                const token = tokens.find(matchTokenByDenom(coin.denom));
                 return token ? (
                   <div key={coin.denom} className="row gap-2">
                     <div className="col ml-auto">
@@ -593,8 +594,8 @@ function EventColumn<
     function getHasInvertedOrder(): boolean {
       return hasInvertedOrder(
         getPairID(Token0, Token1),
-        tokenA.address,
-        tokenB.address
+        tokenA.base,
+        tokenB.base
       );
     }
 
@@ -694,6 +695,8 @@ function SwapColumn({
     data: [tokenAPrice, tokenBPrice],
     isValidating,
   } = useSimplePrice([tokenA, tokenB]);
+  const tokenIdA = getTokenId(tokenA);
+  const tokenIdB = getTokenId(tokenB);
 
   const content = (() => {
     switch (heading) {
@@ -736,14 +739,14 @@ function SwapColumn({
 
     function getTokenAReserves() {
       const address = attributes.Creator;
-      return attributes.TokenIn === tokenA.address
+      return attributes.TokenIn === tokenIdA
         ? getSpentTokenAmount(events, { address, matchToken: tokenA })
         : getReceivedTokenAmount(events, { address, matchToken: tokenA });
     }
 
     function getTokenBReserves() {
       const address = attributes.Creator;
-      return attributes.TokenIn === tokenB.address
+      return attributes.TokenIn === tokenIdB
         ? getSpentTokenAmount(events, { address, matchToken: tokenB })
         : getReceivedTokenAmount(events, { address, matchToken: tokenB });
     }

--- a/src/pages/Pool/PoolOverview.tsx
+++ b/src/pages/Pool/PoolOverview.tsx
@@ -211,15 +211,13 @@ function Incentives({ tokenA, tokenB }: { tokenA?: Token; tokenB?: Token }) {
 
   const { data: { gauges } = {} } = useIncentiveGauges();
   const filteredGauges = useMemo(() => {
-    const tokenAddresses = [getTokenId(tokenA), getTokenId(tokenB)].filter(
-      (address): address is string => !!address
-    );
-    return tokenAddresses.length > 0
+    const tokenIds = [getTokenId(tokenA), getTokenId(tokenB)];
+    return tokenIds.length > 0
       ? gauges?.filter((gauge) => {
-          return tokenAddresses.every((address) => {
+          return tokenIds.every((id) => {
             return (
-              address === gauge.distribute_to?.pairID?.token0 ||
-              address === gauge.distribute_to?.pairID?.token1
+              id === gauge.distribute_to?.pairID?.token0 ||
+              id === gauge.distribute_to?.pairID?.token1
             );
           });
         })

--- a/src/pages/Pool/hooks/useTransactionTableData.ts
+++ b/src/pages/Pool/hooks/useTransactionTableData.ts
@@ -5,6 +5,7 @@ import { Token } from '../../../lib/web3/utils/tokens';
 import { guessInvertedOrder } from '../../../lib/web3/utils/pairs';
 import { DexMessageAction } from '../../../lib/web3/utils/events';
 import { WalletAddress } from '../../../lib/web3/utils/address';
+import { getTokenId } from '../../../lib/web3/hooks/useTokens';
 
 const { REACT_APP__RPC_API = '' } = process.env;
 
@@ -59,19 +60,23 @@ export default function useTransactionTableData({
   action?: DexMessageAction;
   pageSize?: number;
 }) {
+  const tokenIdA = getTokenId(tokenA) || '';
+  const tokenIdB = getTokenId(tokenB) || '';
+
   const [pageOffset] = useState<number>(0);
   return useQuery({
     queryKey: [
       'events',
-      tokenA.address,
-      tokenB.address,
+      tokenIdA,
+      tokenIdB,
       action,
       account,
       pageSize,
       pageOffset,
     ],
+    enabled: !!(tokenIdA && tokenIdB),
     queryFn: async (): Promise<GetTxsEventResponseManuallyType['result']> => {
-      const invertedOrder = guessInvertedOrder(tokenA.address, tokenB.address);
+      const invertedOrder = guessInvertedOrder(tokenIdA, tokenIdB);
 
       /*
        * note: you would expect the following to work, but the ABCI query check
@@ -84,11 +89,11 @@ export default function useTransactionTableData({
        *   events: [
        *     `message.module='${'dex'}'`,
        *     !invertedOrder
-       *       ? `message.Token='${tokenA.address}'`
-       *       : `message.Token0='${tokenB.address}'`,
+       *       ? `message.Token='${tokenIdA}'`
+       *       : `message.Token0='${tokenIdB}'`,
        *     !invertedOrder
-       *       ? `message.Token='${tokenB.address}'`
-       *       : `message.Token1='${tokenA.address}'`,
+       *       ? `message.Token='${tokenIdB}'`
+       *       : `message.Token1='${tokenIdA}'`,
        *     action ? `message.action='${action}'` : '',
        *   ].filter(Boolean),
        *   orderBy: cosmos.tx.v1beta1.OrderBySDKType.ORDER_BY_ASC,
@@ -104,11 +109,11 @@ export default function useTransactionTableData({
           [
             `message.module='${'dex'}'`,
             !invertedOrder
-              ? `message.Token0='${tokenA.address}'`
-              : `message.Token0='${tokenB.address}'`,
+              ? `message.Token0='${tokenIdA}'`
+              : `message.Token0='${tokenIdB}'`,
             !invertedOrder
-              ? `message.Token1='${tokenB.address}'`
-              : `message.Token1='${tokenA.address}'`,
+              ? `message.Token1='${tokenIdB}'`
+              : `message.Token1='${tokenIdA}'`,
             account ? `message.Creator='${account}'` : '',
             action ? `message.action='${action}'` : '',
           ]

--- a/src/pages/Pool/hooks/useTransactionTableData.ts
+++ b/src/pages/Pool/hooks/useTransactionTableData.ts
@@ -1,11 +1,10 @@
 import { useState } from 'react';
 import { useQuery } from '@tanstack/react-query';
 
-import { Token } from '../../../lib/web3/utils/tokens';
+import { Token, getTokenId } from '../../../lib/web3/utils/tokens';
 import { guessInvertedOrder } from '../../../lib/web3/utils/pairs';
 import { DexMessageAction } from '../../../lib/web3/utils/events';
 import { WalletAddress } from '../../../lib/web3/utils/address';
-import { getTokenId } from '../../../lib/web3/hooks/useTokens';
 
 const { REACT_APP__RPC_API = '' } = process.env;
 

--- a/src/pages/Pool/hooks/useTransactionTableData.ts
+++ b/src/pages/Pool/hooks/useTransactionTableData.ts
@@ -76,7 +76,7 @@ export default function useTransactionTableData({
     ],
     enabled: !!(tokenIdA && tokenIdB),
     queryFn: async (): Promise<GetTxsEventResponseManuallyType['result']> => {
-      const invertedOrder = guessInvertedOrder(tokenIdA, tokenIdB);
+      const invertedOrder = guessInvertedOrder([tokenIdA, tokenIdB]);
 
       /*
        * note: you would expect the following to work, but the ABCI query check

--- a/src/pages/Pool/useDeposit.ts
+++ b/src/pages/Pool/useDeposit.ts
@@ -14,7 +14,11 @@ import {
   checkMsgSuccessToast,
   createLoadingToast,
 } from '../../components/Notifications/common';
-import { Token, getDisplayDenomAmount } from '../../lib/web3/utils/tokens';
+import {
+  Token,
+  getDisplayDenomAmount,
+  getTokenId,
+} from '../../lib/web3/utils/tokens';
 import {
   DexDepositEvent,
   mapEventAttributes,
@@ -22,7 +26,6 @@ import {
 import { useOrderedTokenPair } from '../../lib/web3/hooks/useTokenPairs';
 import { useTokenPairTickLiquidity } from '../../lib/web3/hooks/useTickLiquidity';
 import { formatAmount } from '../../lib/utils/number';
-import { getTokenId } from '../../lib/web3/hooks/useTokens';
 
 interface SendDepositResponse {
   gasUsed: string;

--- a/src/pages/Pool/useFeeLiquidityMap.ts
+++ b/src/pages/Pool/useFeeLiquidityMap.ts
@@ -4,12 +4,9 @@ import BigNumber from 'bignumber.js';
 import { useTokenPairTickLiquidity } from '../../lib/web3/hooks/useTickLiquidity';
 import { FeeType, feeTypes } from '../../lib/web3/utils/fees';
 import { calculateShares } from '../../lib/web3/utils/ticks';
-import { TokenAddress } from '../../lib/web3/utils/tokens';
+import { TokenID } from '../../lib/web3/utils/tokens';
 
-export default function useFeeLiquidityMap(
-  tokenA?: TokenAddress,
-  tokenB?: TokenAddress
-) {
+export default function useFeeLiquidityMap(tokenA?: TokenID, tokenB?: TokenID) {
   const {
     data: [token0Ticks, token1Ticks],
     isValidating,

--- a/src/pages/Swap/Swap.tsx
+++ b/src/pages/Swap/Swap.tsx
@@ -14,6 +14,7 @@ import { LimitOrderType } from '@duality-labs/dualityjs/types/codegen/dualitylab
 
 import TokenInputGroup from '../../components/TokenInputGroup';
 import {
+  getTokenId,
   getTokenPathPart,
   useTokenBySymbol,
 } from '../../lib/web3/hooks/useTokens';
@@ -94,8 +95,8 @@ function Swap() {
   const [inputValueB, setInputValueB, valueB = '0'] = useNumericInputState();
   const [lastUpdatedA, setLastUpdatedA] = useState(true);
   const pairRequest = {
-    tokenA: tokenA?.address,
-    tokenB: tokenB?.address,
+    tokenA: getTokenId(tokenA),
+    tokenB: getTokenId(tokenB),
     valueA: lastUpdatedA ? valueA : undefined,
     valueB: lastUpdatedA ? undefined : valueB,
   };
@@ -104,8 +105,8 @@ function Swap() {
     isValidating: isValidatingRate,
     error,
   } = useRouterResult({
-    tokenA: tokenA?.address,
-    tokenB: tokenB?.address,
+    tokenA: getTokenId(tokenA),
+    tokenB: getTokenId(tokenB),
     valueA: lastUpdatedA ? valueA : undefined,
     valueB: lastUpdatedA ? undefined : valueB,
   });
@@ -145,7 +146,7 @@ function Swap() {
     useNumericInputState(defaultSlippage);
 
   const [token0, token1] =
-    useOrderedTokenPair([tokenA?.address, tokenB?.address]) || [];
+    useOrderedTokenPair([getTokenId(tokenA), getTokenId(tokenB)]) || [];
   const {
     data: [token0Ticks, token1Ticks],
   } = useTokenPairTickLiquidity([token0, token1]);
@@ -429,7 +430,7 @@ function Swap() {
                     <>
                       1 {rateTokenOrder[1].symbol} ={' '}
                       {formatLongPrice(
-                        routerResult.tokenIn === rateTokenOrder[1].address
+                        routerResult.tokenIn === getTokenId(rateTokenOrder[1])
                           ? routerResult.amountOut
                               .dividedBy(routerResult.amountIn)
                               .toFixed()

--- a/src/pages/Swap/Swap.tsx
+++ b/src/pages/Swap/Swap.tsx
@@ -14,7 +14,6 @@ import { LimitOrderType } from '@duality-labs/dualityjs/types/codegen/dualitylab
 
 import TokenInputGroup from '../../components/TokenInputGroup';
 import {
-  getTokenId,
   getTokenPathPart,
   useTokenBySymbol,
 } from '../../lib/web3/hooks/useTokens';
@@ -33,7 +32,11 @@ import { getRouterEstimates, useRouterResult } from './hooks/useRouter';
 import { useSwap } from './hooks/useSwap';
 
 import { formatPercentage } from '../../lib/utils/number';
-import { Token, getBaseDenomAmount } from '../../lib/web3/utils/tokens';
+import {
+  Token,
+  getBaseDenomAmount,
+  getTokenId,
+} from '../../lib/web3/utils/tokens';
 import { formatLongPrice } from '../../lib/utils/number';
 
 import './Swap.scss';

--- a/src/pages/Swap/hooks/index.d.ts
+++ b/src/pages/Swap/hooks/index.d.ts
@@ -1,9 +1,9 @@
 import { BigNumber } from 'bignumber.js';
 
 export interface PairRequest {
-  /** address of token A */
+  /** ID of token A */
   tokenA?: string;
-  /** address of token B */
+  /** ID of token B */
   tokenB?: string;
   /** value of token A (falsy if B was just altered) */
   valueA?: string;
@@ -12,9 +12,9 @@ export interface PairRequest {
 }
 
 export interface PairResult {
-  /** address of token A */
+  /** ID of token A */
   tokenA: string;
-  /** address of token B */
+  /** ID of token B */
   tokenB: string;
   /** value for token A */
   valueA: string;
@@ -31,8 +31,8 @@ export interface PairResult {
  * but utilising BigNumber type instead of BigNumberString type properties
  */
 export interface RouterResult {
-  tokenIn: string; // address
-  tokenOut: string; // address
+  tokenIn: string; // token ID
+  tokenOut: string; // token ID
   amountIn: BigNumber;
   amountOut: BigNumber;
   priceBToAIn: BigNumber | undefined;

--- a/src/pages/Swap/hooks/router.ts
+++ b/src/pages/Swap/hooks/router.ts
@@ -109,8 +109,8 @@ export function calculateOut({
   amountIn,
   sortedTicks,
 }: {
-  tokenIn: string; // address
-  tokenOut: string; // address
+  tokenIn: string; // token ID
+  tokenOut: string; // token ID
   amountIn: BigNumber; // amount in (in minimum denom)
   sortedTicks: Array<TickInfo>;
 }): {

--- a/src/pages/Swap/hooks/useRouter.ts
+++ b/src/pages/Swap/hooks/useRouter.ts
@@ -45,7 +45,7 @@ async function getRouterResult(
 
 /**
  * Gets the estimated info of a swap transaction
- * @param pairRequest the respective addresses and value
+ * @param pairRequest the respective IDs and value
  * @returns estimated info of swap, loading state and possible error
  */
 export function useRouterResult(pairRequest: PairRequest): {
@@ -173,7 +173,7 @@ export function useRouterResult(pairRequest: PairRequest): {
 
 /**
  * Gets the estimated info of a swap transaction
- * @param pairRequest the respective addresses and value
+ * @param pairRequest the respective IDs and value
  * @param routerResult the results of the router (if they exist)
  * @returns estimated info of swap
  */
@@ -236,7 +236,7 @@ export function getRouterEstimates(
 
 /**
  * Gets the estimated info of a swap transaction
- * @param pairRequest the respective addresses and value
+ * @param pairRequest the respective IDs and value
  * @returns estimated info of swap, loading state and possible error
  */
 export function useRouterEstimates(pairRequest: PairRequest): {

--- a/src/pages/Swap/hooks/useSwap.tsx
+++ b/src/pages/Swap/hooks/useSwap.tsx
@@ -10,7 +10,7 @@ import { createTransactionToasts } from '../../../components/Notifications/commo
 
 import { getDisplayDenomAmount } from '../../../lib/web3/utils/tokens';
 import useTokens, {
-  matchTokenByAddress,
+  matchTokenByDenom,
   useTokensWithIbcInfo,
 } from '../../../lib/web3/hooks/useTokens';
 import {
@@ -141,7 +141,7 @@ export function useSwap(): [
         return onError('Limit Price is not defined');
       }
 
-      const tokenOutToken = tokens.find(matchTokenByAddress(tokenOut));
+      const tokenOutToken = tokens.find(matchTokenByDenom(tokenOut));
       if (!tokenOutToken) return onError('Token out was not found');
 
       createTransactionToasts(


### PR DESCRIPTION
The previous usage of IBC tokens as improved in 
- #430 

required IBC tokens to have an address field, which was used as the identification field for the token. This appropriation of this field pinned much of the logic in the app to directly referencing the `address` field on tokens for identification and matching. 

This PR abstracts out the identification of IBC or other tokens with a `getTokenID` function. Using this ID we can then look the relevant token from a list of tokens. The token ID is a definition of our choice to help us parse tokens. But in practice this ID has been made the base denom string of all known denoms on the local (Duality) chain, eg.
- `stake`
- `token`
- `tokenA` (dev token mapped to `ATOM/cosmoshub`)
- `tokenB` (dev token mapped to `USDC/ethereum`)
- `ibc/3C3D7B3BE4ECC85A0E5B52A3AEC3B7DFC2AA9CA47C37821E57020D6807043BE9`