### PR TITLE
feat: add staked position parts to be visible in Pool position table

### DIFF
--- a/src/pages/Pool/PoolManagement.tsx
+++ b/src/pages/Pool/PoolManagement.tsx
@@ -799,7 +799,14 @@ export default function PoolManagement({
   const pairPoolDepositFilter = usePoolDepositFilterForPair(
     tokenA && tokenB ? [tokenA, tokenB] : ['', '']
   );
-  const userPositionsContext = useUserPositionsContext(pairPoolDepositFilter);
+  const userUnstakedContext = useUserPositionsContext(pairPoolDepositFilter);
+  const userStakedContext = useUserPositionsContext(
+    pairPoolDepositFilter,
+    true
+  );
+  const userPositionsContext = useMemo(() => {
+    return [...userUnstakedContext, ...userStakedContext];
+  }, [userStakedContext, userUnstakedContext]);
 
   const [{ isValidating: isValidatingEdit }, sendEditRequest] =
     useEditLiquidity();


### PR DESCRIPTION
This PR adds staked positions to be visible and clickable in the normal Pools positions table

Why:
- it seemed odd that the position liquidity would "just disappear" from the position view after it was staked. It should at least be visible even if it cannot be withdrawn because it is staked. 
- allows user to be able to unstake and then withdraw a liquidity position from the same page.