### PR TITLE
fix: better minimum value formatting fixes

### DIFF
--- a/src/components/LiquiditySelector/LiquiditySelector.tsx
+++ b/src/components/LiquiditySelector/LiquiditySelector.tsx
@@ -2019,6 +2019,9 @@ function Axis({
                   ? significantDecimals
                   : 1,
               useGrouping: true,
+            },
+            {
+              reformatSmallValues: false,
             }
           )}
           &nbsp;

--- a/src/lib/utils/number.ts
+++ b/src/lib/utils/number.ts
@@ -62,11 +62,15 @@ export function formatAmount(
   {
     minimumFractionDigits = 0,
     // avoid rendering very long fractional values with a practical limit
-    maximumFractionDigits = Math.max(minimumFractionDigits, 6),
+    maximumFractionDigits: givenMaximumFractionDigits = 6,
     ...numberFormatOptions
   }: Intl.NumberFormatOptions = {},
   { reformatSmallValues = true } = {}
 ) {
+  const maximumFractionDigits = Math.max(
+    minimumFractionDigits,
+    givenMaximumFractionDigits
+  );
   const numericAmount = Number(amount);
   // use passed limits to determine when we show a small value (eg. <0.001)
   const minimumValue = Math.pow(10, -maximumFractionDigits);

--- a/src/pages/Pool/PoolManagement.tsx
+++ b/src/pages/Pool/PoolManagement.tsx
@@ -1332,7 +1332,9 @@ export default function PoolManagement({
                         <div className="chart-highlight">
                           {currentPriceFromTicks !== undefined
                             ? formatAmount(
-                                currentPriceFromTicks.toFixed() || 0,
+                                formatMaximumSignificantDecimals(
+                                  currentPriceFromTicks
+                                ),
                                 { useGrouping: true },
                                 { reformatSmallValues: false }
                               )

--- a/src/pages/Pool/PoolManagement.tsx
+++ b/src/pages/Pool/PoolManagement.tsx
@@ -1331,7 +1331,11 @@ export default function PoolManagement({
                         <strong>Current Price:</strong>
                         <div className="chart-highlight">
                           {currentPriceFromTicks !== undefined
-                            ? formatAmount(currentPriceFromTicks.toFixed() || 0)
+                            ? formatAmount(
+                                currentPriceFromTicks.toFixed() || 0,
+                                { useGrouping: true },
+                                { reformatSmallValues: false }
+                              )
                             : '-'}
                         </div>
                         {tokenA && tokenB && (


### PR DESCRIPTION
This PR fixes some formatted values on the Pool Liquidity chart UI made with previous PR
- #442 

In particular the formatting of the current price on and above the chart.

before:
![localhost_3000_pools_ibc%2F3C3D7B3BE4ECC85A0E5B52A3AEC3B7DFC2AA9CA47C37821E57020D6807043BE9_TKN(FullHD) (4)](https://github.com/duality-labs/duality-web-app/assets/6194521/edadfa2a-5e2a-4021-990f-f83b93167cd5)

after:
![localhost_3000_pools_ibc%2F3C3D7B3BE4ECC85A0E5B52A3AEC3B7DFC2AA9CA47C37821E57020D6807043BE9_TKN(FullHD) (5)](https://github.com/duality-labs/duality-web-app/assets/6194521/079d026a-cdf9-4bc8-9cfb-5ea7b4011ce6)
