### PR TITLE
feat: allow top-level navigation to point to a default token pair

### DIFF
--- a/.env.deploy-previews
+++ b/.env.deploy-previews
@@ -2,10 +2,16 @@
 # each deploy preview has its own unique subdomain, use relative URLs for simplicity here
 PUBLIC_URL=.
 
-# Add prices for development tokens
-REACT_APP__DEV_TOKEN_DENOMS=["sdk.coin:token", "sdk.coin:stake"]
 REACT_APP__IS_MAINNET=testnet
+REACT_APP__DEFAULT_PAIR=STK/TKN
+
+# Add development tokens
+REACT_APP__DEV_ASSET_MAP={"tokenA":"ATOM/cosmoshub","tokenB":"USDC/ethereum","tokenC":"ETH/ethereum","tokenD":"OSMO/osmosis","tokenE":"JUNO/juno","tokenF":"STRD/stride","tokenG":"STARS/stargaze","tokenH":"CRE/crescent","tokenI":"HUAHUA/chihuahua"}
+# Add prices for development tokens
+REACT_APP__DEV_TOKEN_DENOMS=["token","stake"]
+
 
 # Override chain name
 REACT_APP__CHAIN_ID=duality-devnet
 REACT_APP__CHAIN_NAME=Duality Devnet
+REACT_APP__CHAIN_FEE_TOKENS=[{"denom":"stake"}]

--- a/.env.development
+++ b/.env.development
@@ -2,6 +2,7 @@
 PUBLIC_URL=https://app.dev.duality.xyz
 
 REACT_APP__IS_MAINNET=testnet
+REACT_APP__DEFAULT_PAIR=STK/TKN
 
 # Add development tokens
 REACT_APP__DEV_ASSET_MAP={"tokenA":"ATOM/cosmoshub","tokenB":"USDC/ethereum","tokenC":"ETH/ethereum","tokenD":"OSMO/osmosis","tokenE":"JUNO/juno","tokenF":"STRD/stride","tokenG":"STARS/stargaze","tokenH":"CRE/crescent","tokenI":"HUAHUA/chihuahua"}

--- a/src/components/Header/Header.tsx
+++ b/src/components/Header/Header.tsx
@@ -23,7 +23,7 @@ const pageLinkMap = {
   '/bridge': 'Bridge',
 };
 
-const defaultPage = Object.keys(pageLinkMap).at(0) ?? '/';
+export const defaultPage = Object.keys(pageLinkMap).at(0) ?? '/';
 
 export default function Header() {
   const { connectWallet, address } = useWeb3();

--- a/src/components/Header/Header.tsx
+++ b/src/components/Header/Header.tsx
@@ -10,13 +10,15 @@ import Drawer from '../Drawer';
 import logoWithText from '../../assets/logo/logo-with-text-white.svg';
 import './Header.scss';
 
+const { REACT_APP__DEFAULT_PAIR = '' } = process.env;
+
 const keplrLogoURI =
   'https://raw.githubusercontent.com/chainapsis/keplr-wallet/master/docs/.vuepress/public/favicon-256.png';
 
 const pageLinkMap = {
-  '/swap': 'Swap',
+  [['/swap', REACT_APP__DEFAULT_PAIR].join('/')]: 'Swap',
   '/pools': 'Pools',
-  '/orderbook': 'Orderbook',
+  [['/orderbook', REACT_APP__DEFAULT_PAIR].join('/')]: 'Orderbook',
   '/portfolio': 'Portfolio',
   '/bridge': 'Bridge',
 };
@@ -84,7 +86,7 @@ export default function Header() {
           <div className="col">
             <NavLink
               className="logo"
-              to="/swap"
+              to={['/swap', REACT_APP__DEFAULT_PAIR].join('/')}
               onClick={closeMenuAndScrollToTop}
             >
               <h1 className="font-brand">
@@ -180,8 +182,12 @@ export default function Header() {
 }
 
 function NavLink({ to, children, className, ...otherProps }: LinkProps) {
-  const resolved = useResolvedPath(`${to}/*`);
-  const match = useMatch({ path: resolved.pathname, end: true });
+  const resolved = useResolvedPath(to);
+  // match only first path part for "active" class
+  const match = useMatch({
+    path: `/${resolved.pathname.split('/').at(1)}/*`,
+    end: true,
+  });
   const activeClassName = match ? 'active' : '';
   const fullClassName = [className, activeClassName].filter(Boolean).join(' ');
 

--- a/src/components/Header/Header.tsx
+++ b/src/components/Header/Header.tsx
@@ -23,6 +23,8 @@ const pageLinkMap = {
   '/bridge': 'Bridge',
 };
 
+const defaultPage = Object.keys(pageLinkMap).at(0) ?? '/';
+
 export default function Header() {
   const { connectWallet, address } = useWeb3();
   const { themeMode, toggleThemeMode } = useThemeMode();
@@ -86,7 +88,8 @@ export default function Header() {
           <div className="col">
             <NavLink
               className="logo"
-              to={['/swap', REACT_APP__DEFAULT_PAIR].join('/')}
+              // may be redirected by other logic from here
+              to={defaultPage}
               onClick={closeMenuAndScrollToTop}
             >
               <h1 className="font-brand">

--- a/src/pages/App/App.tsx
+++ b/src/pages/App/App.tsx
@@ -1,4 +1,4 @@
-import { Web3Provider, useWeb3 } from '../../lib/web3/useWeb3';
+import { Web3Provider } from '../../lib/web3/useWeb3';
 import { IndexerProvider } from '../../lib/web3/indexerProvider';
 import { ThemeProvider } from '../../lib/themeProvider';
 
@@ -8,6 +8,7 @@ import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 
 import Header from '../../components/Header';
 import Notifications from '../../components/Notifications';
+import { defaultPage } from '../../components/Header/Header';
 
 import Stars from './Stars';
 import Planets from './Planets';
@@ -24,11 +25,6 @@ import './App.scss';
 
 const queryClient = new QueryClient();
 
-function MyLiquidityOrSwap() {
-  const { address } = useWeb3();
-  return address ? <Navigate to="/portfolio" /> : <Navigate to="/swap" />;
-}
-
 function App() {
   return (
     <Web3Provider>
@@ -41,7 +37,7 @@ function App() {
               <Planets />
               <main>
                 <Routes>
-                  <Route index element={<MyLiquidityOrSwap />} />
+                  <Route index element={<Navigate to={defaultPage} />} />
                   <Route path="swap/*" element={<Swap />} />
                   <Route path="pools/*" element={<Pool />} />
                   <Route path="orderbook/*" element={<Orderbook />} />


### PR DESCRIPTION
This PR changes the 
- Swap
- Orderbook

top level links to point directly to a default pair as chosen by the environment variable: `REACT_APP__DEFAULT_PAIR`