### PR TITLE
fix: pay fees using local dev tokens

### DIFF
--- a/.env.deploy-previews
+++ b/.env.deploy-previews
@@ -8,10 +8,10 @@ REACT_APP__DEFAULT_PAIR=NTRN/ATOM
 # Add development tokens
 REACT_APP__DEV_ASSET_MAP={"tokenA":"NTRN/neutron","tokenB":"ATOM/cosmoshub","tokenC":"USDC/ethereum","tokenD":"DAI/gateway","tokenE":"JUNO/juno","tokenF":"STRD/stride","tokenG":"STARS/stargaze","tokenH":"CRE/crescent","tokenI":"HUAHUA/chihuahua","tokenJ":"OSMO/osmosis"}
 # Add prices for development tokens
-REACT_APP__CHAIN_FEE_TOKENS=[{"denom":"tokenA"}]
+REACT_APP__DEV_TOKEN_DENOMS=["token","stake"]
 
 
 # Override chain name
 REACT_APP__CHAIN_ID=duality-devnet
 REACT_APP__CHAIN_NAME=Duality Devnet
-REACT_APP__CHAIN_FEE_TOKENS=[{"denom":"stake"}]
+REACT_APP__CHAIN_FEE_TOKENS=[{"denom":"tokenA"}]

--- a/.env.development
+++ b/.env.development
@@ -8,6 +8,8 @@ REACT_APP__DEFAULT_PAIR=NTRN/ATOM
 
 # Add development tokens
 REACT_APP__DEV_ASSET_MAP={"tokenA":"NTRN/neutron","tokenB":"ATOM/cosmoshub","tokenC":"USDC/ethereum","tokenD":"DAI/gateway","tokenE":"HUAHUA/chihuahua"}
+# Add prices for development tokens
+REACT_APP__DEV_TOKEN_DENOMS=["token","stake"]
 
 # Override chain settings
 REACT_APP__CHAIN_ID=duality-devnet

--- a/src/lib/web3/hooks/useTokens.ts
+++ b/src/lib/web3/hooks/useTokens.ts
@@ -119,11 +119,17 @@ export const devAssets: AssetList | undefined = REACT_APP__DEV_ASSET_MAP
               traces: undefined,
               // overwrite address for token matching
               address,
+              // overwrite base denom for denom matching in Keplr fees
+              base: address,
               // add denom alias for denom exponent matching
               denom_units: foundAsset.denom_units.map((unit) => {
                 return unit.denom === foundAsset.base
-                  ? // add to aliases
-                    { ...unit, aliases: [...(unit.aliases || []), address] }
+                  ? // add token as base denom, move original denom to aliases
+                    {
+                      ...unit,
+                      denom: address,
+                      aliases: [...(unit.aliases || []), unit.denom],
+                    }
                   : unit;
               }),
             }

--- a/src/lib/web3/wallets/keplr.ts
+++ b/src/lib/web3/wallets/keplr.ts
@@ -58,37 +58,7 @@ export async function getKeplrDualityWallet(): Promise<
     invariant(chainId, `Invalid chain id: ${chainId}`);
     const keplr = await getKeplr();
     invariant(keplr, 'Keplr extension is not installed or enabled');
-    await keplr.experimentalSuggestChain({
-      ...chainInfo,
-      currencies: [
-        ...chainInfo.currencies,
-        {
-          coinDenom: 'token',
-          coinMinimalDenom: 'token',
-          coinDecimals: 6,
-          coinGeckoId: 'cosmos',
-        },
-      ],
-      feeCurrencies: [
-        {
-          coinDenom: 'token',
-          coinMinimalDenom: 'token',
-          coinDecimals: 6,
-          coinGeckoId: 'cosmos',
-          gasPriceStep: {
-            low: 0.01,
-            average: 0.025,
-            high: 0.04,
-          },
-        },
-      ],
-      stakeCurrency: {
-        coinDenom: 'token',
-        coinMinimalDenom: 'token',
-        coinDecimals: 6,
-        coinGeckoId: 'cosmos',
-      },
-    });
+    await keplr.experimentalSuggestChain(chainInfo);
     await keplr.enable(chainId);
     const offlineSigner = keplr.getOfflineSigner(chainId);
     invariant(offlineSigner, 'Keplr wallet is not set');


### PR DESCRIPTION
This Fix should allow "Duality Dev Chain" NTRN (aka. `tokenA`) to be used as the Fee currency in Keplr.

It was essential for the token name (eg. `tokenA`) to be set as the token base denom (not just a base denom alias) for this to be picked up by Keplr correctly.