### PR TITLE
feat: optimize tick liquidity fetching through indexer

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -12,6 +12,23 @@ import reportWebVitals from './reportWebVitals';
 import { Buffer } from 'buffer';
 global.Buffer = Buffer;
 
+const { NODE_ENV } = process.env;
+if (NODE_ENV !== 'production') {
+  if ('caches' in window) {
+    caches
+      .keys()
+      .then((cacheKeys) => {
+        return Promise.all(
+          cacheKeys.map((cacheKey) => caches.delete(cacheKey))
+        );
+      })
+      .then(() => {
+        // eslint-disable-next-line no-console
+        console.log('cleared fetch API caches');
+      });
+  }
+}
+
 // ensure App is loaded after Buffer because Keplr needs it on import
 const App = React.lazy(() => import('./pages/App'));
 

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -12,6 +12,7 @@ import reportWebVitals from './reportWebVitals';
 import { Buffer } from 'buffer';
 global.Buffer = Buffer;
 
+// in development, clear the fetch API cache on each reload
 const { NODE_ENV } = process.env;
 if (NODE_ENV !== 'production') {
   if ('caches' in window) {

--- a/src/lib/web3/hooks/useTickLiquidity.ts
+++ b/src/lib/web3/hooks/useTickLiquidity.ts
@@ -71,6 +71,7 @@ function useTickLiquidity({
     enabled: !!queryConfig,
     queryFn: async ({
       pageParam: { nextKey = undefined, height = undefined } = {},
+      signal,
     }): Promise<QueryAllTickLiquidityRangeResponse | undefined> => {
       // build path
       const orderedTokens = new Set(
@@ -118,7 +119,8 @@ function useTickLiquidity({
       const query = queryParams.toString() ? `?${queryParams}` : '';
       // request with appropriate headers
       const response = await fetch(
-        `${REACT_APP__INDEXER_API}/liquidity/token/${path}${query}`
+        `${REACT_APP__INDEXER_API}/liquidity/token/${path}${query}`,
+        { signal }
       );
       // get reserve with Indexer result type
       const result: {

--- a/src/lib/web3/hooks/useTickLiquidity.ts
+++ b/src/lib/web3/hooks/useTickLiquidity.ts
@@ -46,6 +46,15 @@ type QueryAllTickLiquidityState = {
 //   - time to receive first page for ~5,000 list is ~100ms
 const defaultPaginationLimit = 10000;
 
+// only return cache it it is available in this context
+let liquidityCache: Cache | undefined;
+const getLiquidityCache = async () => {
+  if ('caches' in window) {
+    liquidityCache = liquidityCache || (await caches.open('liquidity/token'));
+    return liquidityCache;
+  }
+};
+
 function useTickLiquidity({
   query: queryConfig,
   queryClient: queryClientConfig,
@@ -148,8 +157,7 @@ function useTickLiquidity({
       }
       const query = queryParams.toString() ? `?${queryParams}` : '';
       // use browser Fetch API cache if available
-      const cache =
-        'caches' in window ? await caches.open('liquidity/token') : undefined;
+      const cache = await getLiquidityCache();
       // request with appropriate query
       const urlPath = `${REACT_APP__INDEXER_API}/liquidity/token/${path}`;
       const isInitialRequest = !knownHeight && !nextKey;

--- a/src/lib/web3/hooks/useTickLiquidity.ts
+++ b/src/lib/web3/hooks/useTickLiquidity.ts
@@ -188,10 +188,10 @@ function useTickLiquidity({
                 // and remove empty reserves from array
               ).filter(([key, value]) => value > 0)
             : undefined;
-          const combinedResult: IndexerQueryAllTickLiquidityRangeResponse =
+          const combinedResult = JSON.stringify(
             combinedData
               ? // data is an update
-                {
+                ({
                   block_range: {
                     from_height: Math.min(
                       cachedResult?.block_range.from_height ?? 0,
@@ -212,9 +212,10 @@ function useTickLiquidity({
                         : (cachedResult ?? result).pagination.total,
                     next_key: result.pagination.next_key,
                   },
-                }
+                } as IndexerQueryAllTickLiquidityRangeResponse)
               : // data is a replacement
-                result;
+                result
+          );
           // place in cache for next initial request
           // reset cache to count time since component has unmounted
           setOnUnmount(() => {
@@ -223,10 +224,7 @@ function useTickLiquidity({
             const headers = new Headers();
             headers.set('Cache-Control', 'public, max-age=60');
             headers.set('Date', new Date().toUTCString());
-            cache?.put(
-              urlPath,
-              new Response(JSON.stringify(combinedResult), { headers })
-            );
+            cache?.put(urlPath, new Response(combinedResult, { headers }));
           });
         }
       } catch (e) {

--- a/src/lib/web3/hooks/useTickLiquidity.ts
+++ b/src/lib/web3/hooks/useTickLiquidity.ts
@@ -358,8 +358,11 @@ function usePairLiquidity({
                     ]
                   )
                 ).values()
+              )
                 // and remove empty reserves from array
-              ).filter((poolReserves) => poolReserves.reserves !== '0'),
+                .filter((poolReserves) => poolReserves.reserves !== '0')
+                // re-sort the array (on the reduced length array)
+                .sort((a, b) => b.tickIndex.subtract(a.tickIndex).toNumber()),
               Array.from(
                 // create map out of previous state and new state to ensure new
                 // updates to respective tick indexes overwrite previous state
@@ -371,8 +374,11 @@ function usePairLiquidity({
                     ]
                   )
                 ).values()
+              )
                 // and remove empty reserves from array
-              ).filter((poolReserves) => poolReserves.reserves !== '0'),
+                .filter((poolReserves) => poolReserves.reserves !== '0')
+                // re-sort the array (on the reduced length array)
+                .sort((a, b) => a.tickIndex.subtract(b.tickIndex).toNumber()),
             ];
           } else {
             // eslint-disable-next-line no-console

--- a/src/lib/web3/hooks/useTickLiquidity.ts
+++ b/src/lib/web3/hooks/useTickLiquidity.ts
@@ -199,18 +199,14 @@ function useTickLiquidity({
                 }
               : // data is a replacement
                 result;
-          // specify the cached response is valid for a short period of time:
-          // the liquidity state may have moved if not fetched for a while
-          const headers = new Headers();
-          headers.set('Cache-Control', 'public, max-age=60');
-          headers.set('Date', new Date().toUTCString());
           // place in cache for next initial request
-          await cache.put(
-            path,
-            new Response(JSON.stringify(combinedResult), { headers })
-          );
           // reset cache to count time since component has unmounted
           setOnUnmount(() => {
+            // specify the cached response is valid for a short period of time:
+            // the liquidity state may have moved if not fetched for a while
+            const headers = new Headers();
+            headers.set('Cache-Control', 'public, max-age=60');
+            headers.set('Date', new Date().toUTCString());
             cache?.put(
               path,
               new Response(JSON.stringify(combinedResult), { headers })

--- a/src/lib/web3/hooks/useTickLiquidity.ts
+++ b/src/lib/web3/hooks/useTickLiquidity.ts
@@ -97,22 +97,18 @@ function useTickLiquidity({
         `${REACT_APP__INDEXER_API}/liquidity/token/${path}${query}`,
         {
           headers: {
-            ...(height > 0
-              ? // if we are requesting a "next" page: request the current height
-                {
-                  // eTags should have double quotes for strong conparison
-                  // (strong conparison allows for caching to be used)
-                  'If-Match': `"${height}"`,
-                }
-              : // if not a "next" page, we a starting a new request "chain"
-                // if we already have the data for a current height, request
-                // the next height that does not match this height, ie. long polling
-                // the server should wait until it has new information to return
-                knownChainHeight && {
-                  // eTags should have double quotes for strong conparison
-                  // (strong conparison allows for caching to be used)
-                  'If-None-Match': `"${knownChainHeight}"`,
-                }),
+            ...(height > 0 && {
+              // if we are requesting a "next" page: request the current height
+              // eTags should have double quotes for strong conparison
+              // (strong conparison allows for caching to be used)
+              'If-Match': `"${height}"`,
+            }),
+            ...(knownChainHeight && {
+              // the server should wait until it has new information to return // the next height that does not match this height, ie. long polling // if we already have the data for a current height, request // if not a "next" page, we a starting a new request "chain"
+              // eTags should have double quotes for strong conparison
+              // (strong conparison allows for caching to be used)
+              'If-None-Match': `"${knownChainHeight}"`,
+            }),
           },
         }
       );

--- a/src/lib/web3/hooks/useTickLiquidity.ts
+++ b/src/lib/web3/hooks/useTickLiquidity.ts
@@ -62,6 +62,14 @@ function useTickLiquidity({
     hasNextPage,
     fetchNextPage,
   } = useInfiniteQuery({
+    // note: don't allow "update requests" to be considered stale (refetchable):
+    // when a component loads this hook and this hook contains cached data,
+    // the component will receive the cached progressive update request pages
+    // in order starting from `knownHeight = undefined`, this works well.
+    // but if the data is considered stale then useQuery will send out a request
+    // for each cached page the component reads, generating a lot of requests
+    // and cancelled requests as the component catches up on the known heights
+    staleTime: Infinity,
     queryKey: [
       'dualitylabs.duality.dex.tickLiquidityAll',
       queryConfig?.pairID,

--- a/src/lib/web3/hooks/useTickLiquidity.ts
+++ b/src/lib/web3/hooks/useTickLiquidity.ts
@@ -154,7 +154,7 @@ function useTickLiquidity({
       const urlPath = `${REACT_APP__INDEXER_API}/liquidity/token/${path}`;
       const isInitialRequest = !knownHeight && !nextKey;
       const cachedInitialResponse =
-        isInitialRequest && cache && (await cache.match(path))?.clone();
+        isInitialRequest && cache && (await cache.match(urlPath))?.clone();
       const response =
         // return cached initial response if asked for and available
         cachedInitialResponse ||
@@ -167,7 +167,7 @@ function useTickLiquidity({
       try {
         // skip over saving cache if we just read from it
         if (cache && !cachedInitialResponse) {
-          const cachedResponse = await cache.match(path);
+          const cachedResponse = await cache.match(urlPath);
           const cachedResult:
             | IndexerQueryAllTickLiquidityRangeResponse
             | undefined = await cachedResponse?.json();
@@ -211,7 +211,7 @@ function useTickLiquidity({
             headers.set('Cache-Control', 'public, max-age=60');
             headers.set('Date', new Date().toUTCString());
             cache?.put(
-              path,
+              urlPath,
               new Response(JSON.stringify(combinedResult), { headers })
             );
           });

--- a/src/lib/web3/hooks/useTickLiquidity.ts
+++ b/src/lib/web3/hooks/useTickLiquidity.ts
@@ -41,9 +41,7 @@ type QueryAllTickLiquidityState = {
   error: Error | null;
 };
 
-// experimentally timed that 1000 is faster than 100 or 10,000 items per page
-//   - experiment list length: 1,462 + 5,729 (for each token side)
-//   - time to receive first page for ~5,000 list is ~100ms
+// experimentally timed that a 10,000-25,000 list is a good gzipped size request
 const defaultPaginationLimit = 10000;
 
 // only return cache it it is available in this context
@@ -207,7 +205,10 @@ function useTickLiquidity({
                     total:
                       result.block_range.from_height > 0
                         ? // is update so give final merged length
-                          // note: may be wrong if there are several update pages
+                          // note: may be wrong if there are many update pages
+                          //       it is impossible to know the result from
+                          //       just the total and diff total as some diff
+                          //       updates may remove cumulative reserve items
                           combinedData?.length
                         : (cachedResult ?? result).pagination.total,
                     next_key: result.pagination.next_key,

--- a/src/lib/web3/hooks/useTickLiquidity.ts
+++ b/src/lib/web3/hooks/useTickLiquidity.ts
@@ -197,8 +197,8 @@ function useTickLiquidity({
     if (pages && pages.length > 0) {
       const lastPage = pages[pages.length - 1];
       // update our state only if the last page of data has been reached
-      if (!lastPage?.pagination?.next_key?.length) {
-        const poolReserves = pages?.flatMap(
+      if (lastPage && !lastPage.pagination?.next_key?.length) {
+        const poolReserves = pages.flatMap(
           (page) =>
             page?.tickLiquidity?.flatMap(
               (tickLiquidity) => tickLiquidity.poolReserves ?? []


### PR DESCRIPTION
This PR uses the new pair liquidity long-polling route from the indexer to request real-time up-to-date liquidity data from the chain
- issue: https://github.com/duality-labs/hapi-indexer/issues/24
- PR: https://github.com/duality-labs/hapi-indexer/pull/23

This PR:
- ensures the liquidity data for a token pair is from the same chain height when displayed to end users
- updates with partial liquidity responses
  - which reduces requires data download size by orders of magnitude for each new block update
  - these partial responses are _not diffs_, they represent new `reserves` at each given `tickIndex` of a token pair, so the updates do not lose resolution due to cumulative math operations on rounded numbers
- updates as soon as new data is available: using new long-polling mechanism
