### PR TITLE
fix: dev token prices should all be non zero

### DIFF
--- a/src/lib/tokenPrices.ts
+++ b/src/lib/tokenPrices.ts
@@ -170,9 +170,9 @@ export function useSimplePrice(
   const cachedResults = useMemo(() => {
     // return found results as numbers
     return tokens.map((token) =>
-      data && token?.coingecko_id
+      token?.coingecko_id
         ? // if the information is fetchable, return fetched (number) or not yet fetched (undefined)
-          (data[token.coingecko_id]?.[currencyID] as number | undefined)
+          (data?.[token.coingecko_id]?.[currencyID] as number | undefined)
         : // if the information is not fetchable, return a dev token price or 0 (unpriced)
         isDevToken(token)
         ? 1


### PR DESCRIPTION
This PR fixes the token price of STK and TKN tokens to a price of `1` instead of `0`.

This is achieved by attaching the `devChain` chain to these tokens before tokens have their chain information added (and not overwriting the given `devChain` attribute at that point in time) so that `isDevToken` can do a simple chain attribute comparison to know that these are dev tokens and should be given a dev token price.