### PR TITLE
fix: ensure correct calculated liquidity from usePairLiquidity

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -12,24 +12,6 @@ import reportWebVitals from './reportWebVitals';
 import { Buffer } from 'buffer';
 global.Buffer = Buffer;
 
-// in development, clear the fetch API cache on each reload
-const { NODE_ENV } = process.env;
-if (NODE_ENV !== 'production') {
-  if ('caches' in window) {
-    caches
-      .keys()
-      .then((cacheKeys) => {
-        return Promise.all(
-          cacheKeys.map((cacheKey) => caches.delete(cacheKey))
-        );
-      })
-      .then(() => {
-        // eslint-disable-next-line no-console
-        console.log('cleared fetch API caches');
-      });
-  }
-}
-
 // ensure App is loaded after Buffer because Keplr needs it on import
 const App = React.lazy(() => import('./pages/App'));
 


### PR DESCRIPTION
This fix removes the FetchAPI caching logic for token pair liquidity because the calculated liquidity starting with cached value may be wrong.

    - possibly there is a race condition that saves the wrong state
    - it was found that new Response headers did not affect cache time: the fetchAPI caches the Response value indefinitely
