### PR TITLE
feat: get token pairs list from indexer

### DIFF
--- a/src/lib/web3/hooks/useIndexer.ts
+++ b/src/lib/web3/hooks/useIndexer.ts
@@ -1,0 +1,142 @@
+import { TimeSeriesRow } from '../../../components/stats/utils';
+
+const { REACT_APP__INDEXER_API = '' } = process.env;
+
+type TimeSeries = Map<TimeSeriesRow['0'], TimeSeriesRow>;
+interface StreamCallbacks {
+  // onUpdate returns individual update chunks
+  onUpdate?: (dataset: TimeSeriesRow[]) => void;
+  // onCompleted indicates when the data stream is finished
+  onCompleted?: (dataset: TimeSeries) => void;
+  // onAccumulated returns accumulated TimeSeries so far as a Map
+  onAccumulated?: (dataset: TimeSeries) => void;
+  // allow errors to be seen and handled
+  onError?: (error: Error) => void;
+}
+export class IndexerTimeSeriesStream {
+  // store data in class instance
+  private timeseries: TimeSeries = new Map();
+
+  constructor(relativeURL: URL | string, callbacks: StreamCallbacks) {
+    const url = new URL(relativeURL, REACT_APP__INDEXER_API);
+    // attempt to subscribe to Server-Sent Events
+    this.subscribeToSSE(url, callbacks)
+      // fallback to long-polling if not available
+      .catch(() => this.subscribeToLongPolling(url, callbacks))
+      .catch(() => {
+        // eslint-disable-next-line no-console
+        console.error(
+          `Could not establish a connection to the indexer URL: ${url}`
+        );
+      });
+  }
+
+  // abstracted method to update saved timeseries
+  private accumulateTimeSeries = (dataUpdate: TimeSeriesRow[]): TimeSeries => {
+    dataUpdate.forEach((row) => {
+      this.timeseries.set(row[0], row);
+    });
+    return this.timeseries;
+  };
+
+  private async subscribeToSSE(url: URL, callbacks: StreamCallbacks) {
+    return await new Promise((resolve, reject) => {
+      // create cancellable SSE event source
+      const abortController = this.getNewAbortController();
+      const listenerOptions = { signal: abortController.signal };
+      try {
+        // subscribe to streaming version of URL
+        const streamingURL = new URL(url);
+        streamingURL.searchParams.append('stream', 'true');
+        // add event source and add a cancellation listener
+        const eventSource = new EventSource(streamingURL);
+        abortController.signal.onabort = () => eventSource.close();
+        // listen for updates and remove listener if aborted
+        eventSource.addEventListener(
+          'update',
+          (e: MessageEvent<string>) => {
+            let timeseriesUpdates: TimeSeriesRow[] | undefined;
+            if (e.data) {
+              try {
+                timeseriesUpdates = JSON.parse(e.data) as TimeSeriesRow[];
+              } catch (err) {
+                reject(
+                  new Error(`Could not parse data: ${e.data}`, {
+                    cause: err instanceof Error ? err : new Error(`${err}`),
+                  })
+                );
+              }
+            }
+            if (timeseriesUpdates) {
+              // send update directly to listener
+              callbacks.onUpdate?.(timeseriesUpdates);
+              // update accumulated timeseries
+              const timeseries = this.accumulateTimeSeries(timeseriesUpdates);
+              // send updated timeseries to listener
+              callbacks.onAccumulated?.(timeseries);
+            }
+          },
+          listenerOptions
+        );
+        // 'end' message is sent if a data stream is complete
+        eventSource.addEventListener(
+          'end',
+          () => {
+            // send completed timeseries to listener
+            callbacks.onCompleted?.(this.timeseries);
+            // end promise with completed data
+            resolve(this.timeseries);
+          },
+          listenerOptions
+        );
+        eventSource.addEventListener('error', (e) => {
+          callbacks.onError?.(
+            new Error('SSE error', { cause: new Error(e.type) })
+          );
+        });
+      } catch (e) {
+        reject(
+          new Error('SSE Error', {
+            cause: e instanceof Error ? e : new Error(`${e}`),
+          })
+        );
+      }
+    })
+      // unsubscribe on failure
+      .catch(() => this.unsubscribe());
+  }
+
+  private async subscribeToLongPolling(url: URL, callbacks: StreamCallbacks) {
+    this.timeseries.clear();
+    // todo: add long-polling
+    throw new Error('Long-polling not yet implemented');
+  }
+
+  // restrict class instance to single abort controller
+  private _abortController: AbortController = new AbortController();
+  private getNewAbortController() {
+    // don't subscribe to multiple things at once
+    this._abortController.abort();
+    this._abortController = new AbortController();
+    return this._abortController;
+  }
+
+  // call to unsubscribe from any data stream
+  unsubscribe() {
+    // abort any current requests
+    this._abortController.abort();
+  }
+}
+
+// add higher-level method to fetch multiple pages of data as "one request"
+export async function fetchFromIndexer(url: URL | string): Promise<TimeSeries> {
+  return new Promise((resolve, reject) => {
+    const stream = new IndexerTimeSeriesStream(url, {
+      onCompleted: (timeSeries) => {
+        stream.unsubscribe();
+        resolve(timeSeries);
+      },
+      onError: reject,
+    });
+  });
+}

--- a/src/lib/web3/hooks/useIndexer.ts
+++ b/src/lib/web3/hooks/useIndexer.ts
@@ -157,9 +157,11 @@ export class IndexerStreamAccumulateSingleDataSet<
 
   // abstracted method to update saved dataSet
   private accumulateDataSet = (dataUpdate: DataRow[]) => {
+    const newDataSet = new Map(this.dataSet) as DataSet;
     dataUpdate.forEach((row) => {
-      this.dataSet.set(row[0], row);
+      newDataSet.set(row[0], row);
     });
+    this.dataSet = newDataSet;
     return this.dataSet;
   };
 
@@ -210,9 +212,17 @@ export class IndexerStreamAccumulateDualDataSet<
 
   // abstracted method to update saved dataSet
   private accumulateDataSet = (dataUpdate: DataRow[][]) => {
-    dataUpdate[0].forEach((row) => {
-      this.dataSets[0].set(row[0], row);
-    });
+    const addUpdate = (dataSet: DataSet, dataUpdates: DataRow[]) => {
+      dataUpdates.forEach((row) => {
+        dataSet.set(row[0], row);
+      });
+      return dataSet;
+    };
+    // create new objects (to escape React referential-equality comparision)
+    this.dataSets = [
+      addUpdate(new Map(this.dataSets[0]) as DataSet, dataUpdate[0]),
+      addUpdate(new Map(this.dataSets[1]) as DataSet, dataUpdate[1]),
+    ];
     return this.dataSets;
   };
 

--- a/src/lib/web3/hooks/useIndexer.ts
+++ b/src/lib/web3/hooks/useIndexer.ts
@@ -6,7 +6,7 @@ type FlattenSingularItems<T> = T extends [infer U] ? U : T;
 
 type value = string | number;
 type BaseDataRow = FlattenSingularItems<[id: value, values: value | value[]]>;
-type BaseDataSet<DataRow extends BaseDataRow> = Map<DataRow['0'], DataRow>;
+type BaseDataSet<DataRow extends BaseDataRow> = Map<DataRow['0'], DataRow['1']>;
 
 interface StreamCallbacks<DataRow = BaseDataRow> {
   // onUpdate returns individual update chunks
@@ -135,8 +135,8 @@ function accumulateUpdatesUsingMutation<
   DataSet extends BaseDataSet<DataRow> = BaseDataSet<DataRow>
 >(map: DataSet, dataUpdates: DataRow[]) {
   // add data updates to current map
-  for (const row of dataUpdates) {
-    map.set(row[0], row);
+  for (const [id, data] of dataUpdates) {
+    map.set(id, data);
   }
   return map;
 }

--- a/src/lib/web3/hooks/useIndexer.ts
+++ b/src/lib/web3/hooks/useIndexer.ts
@@ -135,6 +135,8 @@ function accumulateUpdatesUsingMutation<
   DataSet extends BaseDataSet<DataRow> = BaseDataSet<DataRow>
 >(map: DataSet, dataUpdates: DataRow[]) {
   // add data updates to current map
+  // note: if you received an error about here you might be using the incorrect
+  //       indexer class (single/dual datasets) required for the endpoint
   for (const [id, data] of dataUpdates) {
     map.set(id, data);
   }

--- a/src/lib/web3/hooks/useIndexer.ts
+++ b/src/lib/web3/hooks/useIndexer.ts
@@ -264,15 +264,11 @@ function accumulateUpdatesUsingMutation<
 interface StreamSingleDataSetCallbacks<
   DataRow extends BaseDataRow,
   DataSet extends BaseDataSet<DataRow> = BaseDataSet<DataRow>
-> {
-  // onUpdate returns individual update chunks
-  onUpdate?: (update: DataRow[]) => void;
+> extends Omit<StreamCallbacks<DataRow>, 'onCompleted'> {
   // onCompleted indicates when the data stream is finished
   onCompleted?: (dataSet: DataSet) => void;
   // onAccumulated returns accumulated DataSet so far as a Map
   onAccumulated?: (dataSet: DataSet) => void;
-  // allow errors to be seen and handled
-  onError?: (error: Error) => void;
 }
 export class IndexerStreamAccumulateSingleDataSet<
   DataRow extends BaseDataRow,
@@ -327,15 +323,13 @@ export class IndexerStreamAccumulateSingleDataSet<
 interface StreamDualDataSetCallbacks<
   DataRow extends BaseDataRow,
   DataSet extends BaseDataSet<DataRow> = BaseDataSet<DataRow>
-> {
+> extends Omit<StreamCallbacks<DataRow>, 'onUpdate' | 'onCompleted'> {
   // onUpdate returns individual update chunks
   onUpdate?: (update: DataRow[][]) => void;
   // onCompleted indicates when the data stream is finished
   onCompleted?: (dataSet: DataSet[]) => void;
   // onAccumulated returns accumulated DataSet so far as a Map
   onAccumulated?: (dataSet: DataSet[]) => void;
-  // allow errors to be seen and handled
-  onError?: (error: Error) => void;
 }
 export class IndexerStreamAccumulateDualDataSet<
   DataRow extends BaseDataRow,

--- a/src/lib/web3/hooks/useIndexer.ts
+++ b/src/lib/web3/hooks/useIndexer.ts
@@ -1,5 +1,4 @@
 import { useEffect, useState } from 'react';
-import { TimeSeriesRow } from '../../../components/stats/utils';
 
 const { REACT_APP__INDEXER_API = '' } = process.env;
 
@@ -389,40 +388,4 @@ export async function fetchDataFromIndexer<DataRow extends BaseDataRow>(
     // individual data updates
     stream.accumulateUpdates = accumulateUpdatesUsingMutation;
   });
-}
-
-// add time series extended classes
-type TimeSeriesResolution = 'second' | 'minute' | 'hour' | 'day' | 'month';
-
-export class IndexerPriceTimeSeriesStream extends IndexerStreamAccumulateSingleDataSet<TimeSeriesRow> {
-  constructor(
-    symbolA: string,
-    symbolB: string,
-    resolution: TimeSeriesResolution,
-    callbacks: StreamSingleDataSetCallbacks<TimeSeriesRow>,
-    opts?: StreamOptions
-  ) {
-    const relativeURL = `/timeseries/price/${symbolA}/${symbolB}${
-      resolution ? `/${resolution}` : ''
-    }`;
-    super(relativeURL, callbacks, opts);
-    return this;
-  }
-}
-
-// add higher-level method to fetch multiple pages of timeseries data
-export async function fetchPriceTimeSeriesFromIndexer(
-  symbolA: string,
-  symbolB: string,
-  resolution: TimeSeriesResolution,
-  opts?: StreamOptions
-): Promise<BaseDataSet<TimeSeriesRow>> {
-  const url = `/timeseries/price/${symbolA}/${symbolB}${
-    resolution ? `/${resolution}` : ''
-  }`;
-  return await fetchDataFromIndexer(
-    url,
-    IndexerStreamAccumulateSingleDataSet,
-    opts
-  );
 }

--- a/src/lib/web3/hooks/useIndexer.ts
+++ b/src/lib/web3/hooks/useIndexer.ts
@@ -178,9 +178,9 @@ export class IndexerStreamAccumulateSingleDataSet<
         onUpdate: (dataUpdates: DataRow[]) => {
           callbacks.onUpdate?.(dataUpdates);
           // update accumulated dataSet
-          const dataSet = this.accumulateDataSet(dataUpdates);
+          this.dataSet = this.accumulateDataSet(dataUpdates);
           // send updated dataSet to listener
-          callbacks.onAccumulated?.(dataSet);
+          callbacks.onAccumulated?.(this.dataSet);
         },
         onError: callbacks.onError,
         onCompleted: () => callbacks.onCompleted?.(this.dataSet),
@@ -236,9 +236,9 @@ export class IndexerStreamAccumulateDualDataSet<
         onUpdate: (dataUpdates: DataRow[][]) => {
           callbacks.onUpdate?.(dataUpdates);
           // update accumulated dataSet
-          const dataSet = this.accumulateDataSet(dataUpdates);
+          this.dataSets = this.accumulateDataSet(dataUpdates);
           // send updated dataSet to listener
-          callbacks.onAccumulated?.(dataSet);
+          callbacks.onAccumulated?.(this.dataSets);
         },
         onError: callbacks.onError,
         onCompleted: () => callbacks.onCompleted?.(this.dataSets),

--- a/src/lib/web3/hooks/useIndexer.ts
+++ b/src/lib/web3/hooks/useIndexer.ts
@@ -86,11 +86,15 @@ export class IndexerStream<DataRow = BaseDataRow> {
           },
           listenerOptions
         );
-        eventSource.addEventListener('error', (e) => {
-          callbacks.onError?.(
-            new Error('SSE error', { cause: new Error(e.type) })
-          );
-        });
+        eventSource.addEventListener(
+          'error',
+          (e) => {
+            callbacks.onError?.(
+              new Error('SSE error', { cause: new Error(e.type) })
+            );
+          },
+          listenerOptions
+        );
       } catch (e) {
         reject(
           new Error('SSE Error', {

--- a/src/lib/web3/hooks/useIndexer.ts
+++ b/src/lib/web3/hooks/useIndexer.ts
@@ -275,16 +275,14 @@ function useIndexerStream<
   DataSet = BaseDataSet<DataRow>
 >(
   url: URL | string | undefined,
-  IndexerClass: typeof IndexerStreamAccumulateSingleDataSet,
-  opts?: StreamOptions
+  IndexerClass: typeof IndexerStreamAccumulateSingleDataSet
 ): StaleWhileRevalidateState<DataSet>;
 function useIndexerStream<
   DataRow extends BaseDataRow,
   DataSet = BaseDataSet<DataRow>
 >(
   url: URL | string | undefined,
-  IndexerClass: typeof IndexerStreamAccumulateDualDataSet,
-  opts?: StreamOptions
+  IndexerClass: typeof IndexerStreamAccumulateDualDataSet
 ): StaleWhileRevalidateState<DataSet[]>;
 function useIndexerStream<
   DataRow extends BaseDataRow,
@@ -293,8 +291,7 @@ function useIndexerStream<
   url: URL | string | undefined,
   IndexerClass:
     | typeof IndexerStreamAccumulateSingleDataSet
-    | typeof IndexerStreamAccumulateDualDataSet,
-  opts?: StreamOptions
+    | typeof IndexerStreamAccumulateDualDataSet
 ): StaleWhileRevalidateState<DataSet | DataSet[]> {
   const [dataset, setDataSet] = useState<DataSet | DataSet[]>();
   const [isValidating, setIsValidating] = useState<boolean>(false);
@@ -304,23 +301,19 @@ function useIndexerStream<
   useEffect(() => {
     if (url) {
       setIsValidating(true);
-      const stream = new IndexerClass<DataRow>(
-        url,
-        {
-          onAccumulated: (dataSet) => {
-            // note: the TypeScript here is a bit hacky but this should be ok
-            setDataSet(dataSet as unknown as DataSet | DataSet[]);
-          },
-          onCompleted: () => setIsValidating(false),
-          onError: (error) => setError(error),
+      const stream = new IndexerClass<DataRow>(url, {
+        onAccumulated: (dataSet) => {
+          // note: the TypeScript here is a bit hacky but this should be ok
+          setDataSet(dataSet as unknown as DataSet | DataSet[]);
         },
-        opts
-      );
+        onCompleted: () => setIsValidating(false),
+        onError: (error) => setError(error),
+      });
       return () => {
         stream.unsubscribe();
       };
     }
-  }, [IndexerClass, opts, url]);
+  }, [IndexerClass, url]);
 
   return { data: dataset, isValidating, error };
 }
@@ -329,11 +322,10 @@ function useIndexerStream<
 export function useIndexerStreamOfSingleDataSet<
   DataRow extends BaseDataRow,
   DataSet = BaseDataSet<DataRow>
->(url: URL | string | undefined, opts?: StreamOptions) {
+>(url: URL | string | undefined) {
   return useIndexerStream<DataRow, DataSet>(
     url,
-    IndexerStreamAccumulateSingleDataSet,
-    opts
+    IndexerStreamAccumulateSingleDataSet
   );
 }
 
@@ -344,8 +336,7 @@ export function useIndexerStreamOfDualDataSet<
 >(url: URL | string | undefined, opts?: StreamOptions) {
   return useIndexerStream<DataRow, DataSet>(
     url,
-    IndexerStreamAccumulateDualDataSet,
-    opts
+    IndexerStreamAccumulateDualDataSet
   );
 }
 

--- a/src/lib/web3/hooks/useIndexer.ts
+++ b/src/lib/web3/hooks/useIndexer.ts
@@ -16,8 +16,21 @@ interface StreamCallbacks<DataRow = BaseDataRow> {
   // allow errors to be seen and handled
   onError?: (error: Error) => void;
 }
+interface StreamOptions {
+  // optional single AbortController for all the requests
+  abortController?: AbortController;
+}
 export class IndexerStream<DataRow = BaseDataRow> {
-  constructor(relativeURL: URL | string, callbacks: StreamCallbacks<DataRow>) {
+  // use single AbortController for all the requests
+  private abortController = new AbortController();
+
+  constructor(
+    relativeURL: URL | string,
+    callbacks: StreamCallbacks<DataRow>,
+    opts?: StreamOptions
+  ) {
+    // replace abortController if one is given
+    this.abortController = opts?.abortController ?? this.abortController;
     const url = new URL(relativeURL, REACT_APP__INDEXER_API);
     // attempt to subscribe to Server-Sent Events
     this.subscribeToSSE(url, callbacks)
@@ -34,15 +47,14 @@ export class IndexerStream<DataRow = BaseDataRow> {
   private async subscribeToSSE(url: URL, callbacks: StreamCallbacks<DataRow>) {
     return await new Promise<void>((resolve, reject) => {
       // create cancellable SSE event source
-      const abortController = this.getNewAbortController();
-      const listenerOptions = { signal: abortController.signal };
+      const listenerOptions = { signal: this.abortController.signal };
       try {
         // subscribe to streaming version of URL
         const streamingURL = new URL(url);
         streamingURL.searchParams.append('stream', 'true');
         // add event source and add a cancellation listener
         const eventSource = new EventSource(streamingURL);
-        abortController.signal.onabort = () => eventSource.close();
+        this.abortController.signal.onabort = () => eventSource.close();
         // listen for updates and remove listener if aborted
         eventSource.addEventListener(
           'update',
@@ -102,19 +114,10 @@ export class IndexerStream<DataRow = BaseDataRow> {
     throw new Error('Long-polling not yet implemented');
   }
 
-  // restrict class instance to single abort controller
-  private _abortController: AbortController = new AbortController();
-  private getNewAbortController() {
-    // don't subscribe to multiple things at once
-    this._abortController.abort();
-    this._abortController = new AbortController();
-    return this._abortController;
-  }
-
   // call to unsubscribe from any data stream
   unsubscribe() {
     // abort any current requests
-    this._abortController.abort();
+    this.abortController.abort();
   }
 }
 
@@ -163,19 +166,24 @@ export class IndexerStreamAccumulateSingleDataSet<
 
   constructor(
     relativeURL: URL | string,
-    callbacks: StreamSingleDataSetCallbacks<DataRow>
+    callbacks: StreamSingleDataSetCallbacks<DataRow>,
+    opts?: StreamOptions
   ) {
-    this.stream = new IndexerStream(relativeURL, {
-      onUpdate: (dataUpdates: DataRow[]) => {
-        callbacks.onUpdate?.(dataUpdates);
-        // update accumulated dataSet
-        const dataSet = this.accumulateDataSet(dataUpdates);
-        // send updated dataSet to listener
-        callbacks.onAccumulated?.(dataSet);
+    this.stream = new IndexerStream<DataRow>(
+      relativeURL,
+      {
+        onUpdate: (dataUpdates: DataRow[]) => {
+          callbacks.onUpdate?.(dataUpdates);
+          // update accumulated dataSet
+          const dataSet = this.accumulateDataSet(dataUpdates);
+          // send updated dataSet to listener
+          callbacks.onAccumulated?.(dataSet);
+        },
+        onError: callbacks.onError,
+        onCompleted: () => callbacks.onCompleted?.(this.dataSet),
       },
-      onError: callbacks.onError,
-      onCompleted: () => callbacks.onCompleted?.(this.dataSet),
-    });
+      opts
+    );
   }
 
   // abstracted method to update saved dataSet
@@ -216,19 +224,24 @@ export class IndexerStreamAccumulateDualDataSet<
 
   constructor(
     relativeURL: URL | string,
-    callbacks: StreamDualDataSetCallbacks<DataRow>
+    callbacks: StreamDualDataSetCallbacks<DataRow>,
+    opts?: StreamOptions
   ) {
-    this.stream = new IndexerStream<DataRow[]>(relativeURL, {
-      onUpdate: (dataUpdates: DataRow[][]) => {
-        callbacks.onUpdate?.(dataUpdates);
-        // update accumulated dataSet
-        const dataSet = this.accumulateDataSet(dataUpdates);
-        // send updated dataSet to listener
-        callbacks.onAccumulated?.(dataSet);
+    this.stream = new IndexerStream<DataRow[]>(
+      relativeURL,
+      {
+        onUpdate: (dataUpdates: DataRow[][]) => {
+          callbacks.onUpdate?.(dataUpdates);
+          // update accumulated dataSet
+          const dataSet = this.accumulateDataSet(dataUpdates);
+          // send updated dataSet to listener
+          callbacks.onAccumulated?.(dataSet);
+        },
+        onError: callbacks.onError,
+        onCompleted: () => callbacks.onCompleted?.(this.dataSets),
       },
-      onError: callbacks.onError,
-      onCompleted: () => callbacks.onCompleted?.(this.dataSets),
-    });
+      opts
+    );
   }
 
   // abstracted method to update saved dataSet
@@ -262,14 +275,16 @@ function useIndexerStream<
   DataSet = BaseDataSet<DataRow>
 >(
   url: URL | string | undefined,
-  IndexerClass: typeof IndexerStreamAccumulateSingleDataSet
+  IndexerClass: typeof IndexerStreamAccumulateSingleDataSet,
+  opts?: StreamOptions
 ): StaleWhileRevalidateState<DataSet>;
 function useIndexerStream<
   DataRow extends BaseDataRow,
   DataSet = BaseDataSet<DataRow>
 >(
   url: URL | string | undefined,
-  IndexerClass: typeof IndexerStreamAccumulateDualDataSet
+  IndexerClass: typeof IndexerStreamAccumulateDualDataSet,
+  opts?: StreamOptions
 ): StaleWhileRevalidateState<DataSet[]>;
 function useIndexerStream<
   DataRow extends BaseDataRow,
@@ -278,27 +293,34 @@ function useIndexerStream<
   url: URL | string | undefined,
   IndexerClass:
     | typeof IndexerStreamAccumulateSingleDataSet
-    | typeof IndexerStreamAccumulateDualDataSet
+    | typeof IndexerStreamAccumulateDualDataSet,
+  opts?: StreamOptions
 ): StaleWhileRevalidateState<DataSet | DataSet[]> {
   const [dataset, setDataSet] = useState<DataSet | DataSet[]>();
   const [isValidating, setIsValidating] = useState<boolean>(false);
   const [error, setError] = useState<Error>();
 
+  // todo: use deep-compare effect to not cause unneccessary updates from url or opts
   useEffect(() => {
     if (url) {
       setIsValidating(true);
-      const stream = new IndexerClass<DataRow>(url, {
-        onAccumulated: (dataSet) =>
-          // note: the TypeScript here is a bit hacky but this should be ok here
-          setDataSet(dataSet as unknown as DataSet | DataSet[]),
-        onCompleted: () => setIsValidating(false),
-        onError: (error) => setError(error),
-      });
+      const stream = new IndexerClass<DataRow>(
+        url,
+        {
+          onAccumulated: (dataSet) => {
+            // note: the TypeScript here is a bit hacky but this should be ok
+            setDataSet(dataSet as unknown as DataSet | DataSet[]);
+          },
+          onCompleted: () => setIsValidating(false),
+          onError: (error) => setError(error),
+        },
+        opts
+      );
       return () => {
         stream.unsubscribe();
       };
     }
-  }, [IndexerClass, url]);
+  }, [IndexerClass, opts, url]);
 
   return { data: dataset, isValidating, error };
 }
@@ -307,10 +329,11 @@ function useIndexerStream<
 export function useIndexerStreamOfSingleDataSet<
   DataRow extends BaseDataRow,
   DataSet = BaseDataSet<DataRow>
->(url: URL | string | undefined) {
+>(url: URL | string | undefined, opts?: StreamOptions) {
   return useIndexerStream<DataRow, DataSet>(
     url,
-    IndexerStreamAccumulateSingleDataSet
+    IndexerStreamAccumulateSingleDataSet,
+    opts
   );
 }
 
@@ -318,27 +341,31 @@ export function useIndexerStreamOfSingleDataSet<
 export function useIndexerStreamOfDualDataSet<
   DataRow extends BaseDataRow,
   DataSet = BaseDataSet<DataRow>
->(url: URL | string | undefined) {
+>(url: URL | string | undefined, opts?: StreamOptions) {
   return useIndexerStream<DataRow, DataSet>(
     url,
-    IndexerStreamAccumulateDualDataSet
+    IndexerStreamAccumulateDualDataSet,
+    opts
   );
 }
 
 // add higher-level function to fetch multiple pages of data as "one request"
 export async function fetchDataFromIndexer<DataRow extends BaseDataRow>(
   baseURL: URL | string,
-  IndexerClass: typeof IndexerStreamAccumulateSingleDataSet
+  IndexerClass: typeof IndexerStreamAccumulateSingleDataSet,
+  opts?: StreamOptions
 ): Promise<BaseDataSet<DataRow>>;
 export async function fetchDataFromIndexer<DataRow extends BaseDataRow>(
   baseURL: URL | string,
-  IndexerClass: typeof IndexerStreamAccumulateDualDataSet
+  IndexerClass: typeof IndexerStreamAccumulateDualDataSet,
+  opts?: StreamOptions
 ): Promise<BaseDataSet<DataRow>[]>;
 export async function fetchDataFromIndexer<DataRow extends BaseDataRow>(
   baseURL: URL | string,
   IndexerClass:
     | typeof IndexerStreamAccumulateSingleDataSet
-    | typeof IndexerStreamAccumulateDualDataSet
+    | typeof IndexerStreamAccumulateDualDataSet,
+  opts?: StreamOptions
 ): Promise<BaseDataSet<DataRow> | BaseDataSet<DataRow>[]> {
   return new Promise((resolve, reject) => {
     const url = new URL(baseURL, REACT_APP__INDEXER_API);
@@ -346,13 +373,17 @@ export async function fetchDataFromIndexer<DataRow extends BaseDataRow>(
     const before = Date.now() / 1000;
     url.searchParams.append('pagination.before', before.toFixed(0));
     // add stream listener and resolve promise on completion
-    const stream = new IndexerClass<DataRow>(url, {
-      onCompleted: (data) => {
-        stream.unsubscribe();
-        resolve(data);
+    const stream = new IndexerClass<DataRow>(
+      url,
+      {
+        onCompleted: (data) => {
+          stream.unsubscribe();
+          resolve(data);
+        },
+        onError: reject,
       },
-      onError: reject,
-    });
+      opts
+    );
     // allow mutation in this stream accumulator because we won't listen to
     // individual data updates
     stream.accumulateUpdates = accumulateUpdatesUsingMutation;
@@ -367,12 +398,13 @@ export class IndexerPriceTimeSeriesStream extends IndexerStreamAccumulateSingleD
     symbolA: string,
     symbolB: string,
     resolution: TimeSeriesResolution,
-    callbacks: StreamSingleDataSetCallbacks<TimeSeriesRow>
+    callbacks: StreamSingleDataSetCallbacks<TimeSeriesRow>,
+    opts?: StreamOptions
   ) {
     const relativeURL = `/timeseries/price/${symbolA}/${symbolB}${
       resolution ? `/${resolution}` : ''
     }`;
-    super(relativeURL, callbacks);
+    super(relativeURL, callbacks, opts);
     return this;
   }
 }
@@ -381,10 +413,15 @@ export class IndexerPriceTimeSeriesStream extends IndexerStreamAccumulateSingleD
 export async function fetchPriceTimeSeriesFromIndexer(
   symbolA: string,
   symbolB: string,
-  resolution: TimeSeriesResolution
+  resolution: TimeSeriesResolution,
+  opts?: StreamOptions
 ): Promise<BaseDataSet<TimeSeriesRow>> {
   const url = `/timeseries/price/${symbolA}/${symbolB}${
     resolution ? `/${resolution}` : ''
   }`;
-  return await fetchDataFromIndexer(url, IndexerStreamAccumulateSingleDataSet);
+  return await fetchDataFromIndexer(
+    url,
+    IndexerStreamAccumulateSingleDataSet,
+    opts
+  );
 }

--- a/src/lib/web3/hooks/useIndexer.ts
+++ b/src/lib/web3/hooks/useIndexer.ts
@@ -49,11 +49,8 @@ export class IndexerStream<DataRow = BaseDataRow> {
       // create cancellable SSE event source
       const listenerOptions = { signal: this.abortController.signal };
       try {
-        // subscribe to streaming version of URL
-        const streamingURL = new URL(url);
-        streamingURL.searchParams.append('stream', 'true');
         // add event source and add a cancellation listener
-        const eventSource = new EventSource(streamingURL);
+        const eventSource = new EventSource(url);
         this.abortController.signal.onabort = () => eventSource.close();
         // listen for updates and remove listener if aborted
         eventSource.addEventListener(

--- a/src/lib/web3/hooks/useIndexer.ts
+++ b/src/lib/web3/hooks/useIndexer.ts
@@ -5,7 +5,8 @@ const { REACT_APP__INDEXER_API = '' } = process.env;
 
 type FlattenSingularItems<T> = T extends [infer U] ? U : T;
 
-type BaseDataRow = FlattenSingularItems<[id: number, values: number[]]>;
+type value = string | number;
+type BaseDataRow = FlattenSingularItems<[id: value, values: value[]]>;
 type BaseDataSet<DataRow extends BaseDataRow> = Map<DataRow['0'], DataRow>;
 
 interface StreamCallbacks<DataRow = BaseDataRow> {

--- a/src/lib/web3/hooks/useIndexer.ts
+++ b/src/lib/web3/hooks/useIndexer.ts
@@ -5,7 +5,7 @@ const { REACT_APP__INDEXER_API = '' } = process.env;
 type FlattenSingularItems<T> = T extends [infer U] ? U : T;
 
 type value = string | number;
-type BaseDataRow = FlattenSingularItems<[id: value, values: value[]]>;
+type BaseDataRow = FlattenSingularItems<[id: value, values: value | value[]]>;
 type BaseDataSet<DataRow extends BaseDataRow> = Map<DataRow['0'], DataRow>;
 
 interface StreamCallbacks<DataRow = BaseDataRow> {

--- a/src/lib/web3/hooks/useTokenPairs.ts
+++ b/src/lib/web3/hooks/useTokenPairs.ts
@@ -1,109 +1,37 @@
-import Long from 'long';
-import { useEffect, useMemo } from 'react';
-
-import { useLcdClientPromise } from '../lcdClient';
-
-import {
-  QueryTotalSupplyRequest,
-  QueryTotalSupplyResponse,
-} from '@duality-labs/dualityjs/types/codegen/cosmos/bank/v1beta1/query';
-import { getShareInfo } from '../utils/shares';
-import { getPairID } from '../utils/pairs';
 import { TokenAddress } from '../utils/tokens';
-import { useInfiniteQuery } from '@tanstack/react-query';
+import { useIndexerStreamOfSingleDataSet } from './useIndexer';
 
-type QueryAllTokenMapState = {
-  data: [TokenAddress, TokenAddress][] | undefined;
+export type TokenPairReserves = [
+  token0: TokenAddress,
+  token1: TokenAddress,
+  reserve0: number,
+  reserve1: number
+];
+type DataRow = [index: number, values: TokenPairReserves];
+
+type TokenPairsState = {
+  data: TokenPairReserves[] | undefined;
   isValidating: boolean;
   error: Error | null;
 };
 
-// experimentally timed that 250 is faster than 100 or 1000 items per page
-//   - experiment list length: 7,220)
-const defaultPaginationLimit = Long.fromNumber(250);
+export default function useTokenPairs(): TokenPairsState {
+  const { data, isValidating, error } =
+    useIndexerStreamOfSingleDataSet<DataRow>('/liquidity/pairs');
 
-export default function useTokenPairs({
-  queryOptions,
-  query: queryConfig,
-  queryClient: queryClientConfig,
-}: {
-  // todo: pass entire useQuery options set here
-  queryOptions?: { refetchInterval: number | false };
-  query?: QueryTotalSupplyRequest;
-  queryClient?: string;
-} = {}): QueryAllTokenMapState {
-  const lcdClientPromise = useLcdClientPromise(queryClientConfig);
-
-  const {
-    data,
-    error,
-    isFetching: isValidating,
-    hasNextPage,
-    fetchNextPage,
-  } = useInfiniteQuery({
-    ...queryOptions,
-    queryKey: ['cosmos.bank.v1beta1.totalSupply'],
-    queryFn: async ({
-      pageParam: nextKey,
-    }): Promise<QueryTotalSupplyResponse | undefined> => {
-      const client = await lcdClientPromise;
-      return await client.cosmos.bank.v1beta1.totalSupply({
-        ...queryConfig,
-        pagination: {
-          limit: defaultPaginationLimit,
-          ...queryConfig?.pagination,
-          ...(nextKey && {
-            key: nextKey,
-          }),
-        },
-      });
-    },
-    defaultPageParam: undefined,
-    getNextPageParam: (lastPage: QueryTotalSupplyResponse | undefined) => {
-      // don't pass an empty array as that will trigger another page to download
-      return lastPage?.pagination?.next_key?.length
-        ? lastPage?.pagination?.next_key
-        : undefined;
-    },
-  });
-
-  // fetch more data if data has changed but there are still more pages to get
-  useEffect(() => {
-    if (fetchNextPage && hasNextPage) {
-      fetchNextPage();
-    }
-  }, [data, fetchNextPage, hasNextPage]);
-
-  // place pages of data into the same list
-  const tradingPairs = useMemo(() => {
-    const tradingPairMap = data?.pages?.reduce<
-      Map<string, [TokenAddress, TokenAddress]>
-    >((acc, page) => {
-      page?.supply.forEach((coin) => {
-        const match = getShareInfo(coin);
-        if (match) {
-          const { token0Address, token1Address } = match;
-          acc.set(getPairID(token0Address, token1Address), [
-            token0Address,
-            token1Address,
-          ]);
-        }
-      });
-
-      return acc;
-    }, new Map<string, [TokenAddress, TokenAddress]>());
-    return tradingPairMap && Array.from(tradingPairMap.values());
-  }, [data]);
-
+  if (data) {
+    const values = Array.from(data, (row) => row[1][1] as TokenPairReserves);
+    return { data: values, isValidating, error: error || null };
+  }
   // return state
-  return { data: tradingPairs, isValidating, error };
+  return { data: undefined, isValidating, error: error || null };
 }
 
 // add convenience method to fetch ticks in a pair
 export function useOrderedTokenPair([tokenA, tokenB]: [
   TokenAddress?,
   TokenAddress?
-]): [token0: TokenAddress, token1: TokenAddress] | undefined {
+]): TokenPairReserves | undefined {
   const { data: tokenPairs } = useTokenPairs();
   // search for ordered token pair in our token pair list
   return tokenA && tokenB

--- a/src/lib/web3/hooks/useTokenPairs.ts
+++ b/src/lib/web3/hooks/useTokenPairs.ts
@@ -1,3 +1,4 @@
+import { useMemo } from 'react';
 import { TokenAddress } from '../utils/tokens';
 import { useIndexerStreamOfSingleDataSet } from './useIndexer';
 
@@ -19,12 +20,17 @@ export default function useTokenPairs(): TokenPairsState {
   const { data, isValidating, error } =
     useIndexerStreamOfSingleDataSet<DataRow>('/liquidity/pairs');
 
-  if (data) {
-    const values = Array.from(data, (row) => row[1][1] as TokenPairReserves);
-    return { data: values, isValidating, error: error || null };
-  }
+  const values: TokenPairReserves[] | undefined = useMemo(() => {
+    if (data) {
+      const values = Array.from(data, (row) => row[1])
+        .sort(([a], [b]) => a - b)
+        .map((row) => row[1]);
+      return values;
+    }
+  }, [data]);
+
   // return state
-  return { data: undefined, isValidating, error: error || null };
+  return { data: values, isValidating, error: error || null };
 }
 
 // add convenience method to fetch ticks in a pair

--- a/src/lib/web3/hooks/useTokenPairs.ts
+++ b/src/lib/web3/hooks/useTokenPairs.ts
@@ -21,7 +21,7 @@ export default function useTokenPairs(): TokenPairsState {
 
   const values: TokenPairReserves[] | undefined = useMemo(() => {
     if (data) {
-      const values = Array.from(data, (row) => row[1])
+      const values = Array.from(data)
         .sort(([a], [b]) => a - b)
         .map((row) => row[1]);
       return values;

--- a/src/lib/web3/hooks/useTokenPairs.ts
+++ b/src/lib/web3/hooks/useTokenPairs.ts
@@ -12,12 +12,11 @@ type DataRow = [index: number, values: TokenPairReserves];
 
 type TokenPairsState = {
   data: TokenPairReserves[] | undefined;
-  isValidating: boolean;
   error: Error | null;
 };
 
 export default function useTokenPairs(): TokenPairsState {
-  const { data, isValidating, error } =
+  const { data, error } =
     useIndexerStreamOfSingleDataSet<DataRow>('/liquidity/pairs');
 
   const values: TokenPairReserves[] | undefined = useMemo(() => {
@@ -30,7 +29,7 @@ export default function useTokenPairs(): TokenPairsState {
   }, [data]);
 
   // return state
-  return { data: values, isValidating, error: error || null };
+  return { data: values, error: error || null };
 }
 
 // add convenience method to fetch ticks in a pair


### PR DESCRIPTION
Using the new token pairs list from:
- https://github.com/duality-labs/hapi-indexer/issues/17

and the real-time SSE update mechanism from 
- https://github.com/duality-labs/hapi-indexer/issues/37

This PR allows the token pairs list to be taken from the `/liquidity/pairs` endpoint of the indexer, instead of being derived from iterating through all existing ticks of the `/cosmos/bank/v1beta1/supply` of the LCD API (which will not be feasible in production, and is not possible after the backend change: https://github.com/duality-labs/duality/pull/456 which is part of v0.4.1 of the Duality chain)