### PR TITLE
fix: add TradingView charts fix

### DIFF
--- a/.github/workflows/deploy_semantic_release.yml
+++ b/.github/workflows/deploy_semantic_release.yml
@@ -51,7 +51,7 @@ jobs:
             conventional-changelog-conventionalcommits@6
         env:
           # use GitHub action token to post comment to PR
-          GITHUB_TOKEN: ${{ github.token }}
+          GITHUB_TOKEN: ${{ secrets.GH_TOKEN }}
 
       - name: Echo new release
         if: steps.semantic.outputs.new_release_published == 'true'


### PR DESCRIPTION
I tried to restrict the CI permissions a bit too much

This PR fixes the CI process on main:
- semantic release needs push access to add semantic release commit