### PR TITLE
fix: improve token denom handling for IBC tokens: part 2b

### DIFF
--- a/src/lib/web3/hooks/useChains.ts
+++ b/src/lib/web3/hooks/useChains.ts
@@ -1,16 +1,28 @@
 import { Chain } from '@chain-registry/types';
-import { useMemo } from 'react';
+import { useEffect, useMemo } from 'react';
 import { ibc, router } from '@duality-labs/dualityjs';
 import { QueryParamsResponse as QueryRouterParams } from '@duality-labs/dualityjs/types/codegen/router/v1/query';
-import { QueryClientStatesResponse } from '@duality-labs/dualityjs/types/codegen/ibc/core/client/v1/query';
 import { Params as QueryConnectionParams } from '@duality-labs/dualityjs/types/codegen/ibc/core/connection/v1/connection';
-import { QueryConnectionsResponse } from '@duality-labs/dualityjs/types/codegen/ibc/core/connection/v1/query';
-import { QueryChannelsResponse } from '@duality-labs/dualityjs/types/codegen/ibc/core/channel/v1/query';
+import {
+  QueryClientStatesRequest,
+  QueryClientStatesResponse,
+} from '@duality-labs/dualityjs/types/codegen/ibc/core/client/v1/query';
+import {
+  QueryConnectionsRequest,
+  QueryConnectionsResponse,
+} from '@duality-labs/dualityjs/types/codegen/ibc/core/connection/v1/query';
+import {
+  QueryChannelsRequest,
+  QueryChannelsResponse,
+} from '@duality-labs/dualityjs/types/codegen/ibc/core/channel/v1/query';
 import { QueryBalanceResponse } from '@duality-labs/dualityjs/types/codegen/cosmos/bank/v1beta1/query';
 import { State as ChannelState } from '@duality-labs/dualityjs/types/codegen/ibc/core/channel/v1/channel';
 import { State as ConnectionState } from '@duality-labs/dualityjs/types/codegen/ibc/core/connection/v1/connection';
-import { useQuery } from '@tanstack/react-query';
-import { useDeepCompareMemoize } from 'use-deep-compare-effect';
+import {
+  UseInfiniteQueryResult,
+  useInfiniteQuery,
+  useQuery,
+} from '@tanstack/react-query';
 
 import { getChainInfo } from '../wallets/keplr';
 import dualityLogo from '../../../assets/logo/logo.svg';
@@ -91,11 +103,27 @@ async function getIbcLcdClient(
   }
 }
 
+function useFetchAllPaginatedPages(results: UseInfiniteQueryResult) {
+  const { fetchNextPage, isFetchingNextPage, hasNextPage } = results;
+  // fetch more data if data has changed but there are still more pages to get
+  useEffect(() => {
+    if (hasNextPage && !isFetchingNextPage) {
+      // cancelRefetch will create a new request for each hook
+      // and should not be done here because this is an effect not a user action
+      fetchNextPage({ cancelRefetch: false });
+    }
+  }, [fetchNextPage, isFetchingNextPage, hasNextPage]);
+}
+
 function useIbcClientStates(chain: Chain) {
   const { data: restEndpoint } = useRemoteChainRestEndpoint(chain);
-  return useQuery({
+  const results = useInfiniteQuery({
     queryKey: ['ibc-client-states', restEndpoint],
-    queryFn: async (): Promise<QueryClientStatesResponse> => {
+    queryFn: async ({
+      pageParam: key,
+    }: {
+      pageParam?: Uint8Array;
+    }): Promise<QueryClientStatesResponse> => {
       // get IBC LCD client
       const lcd = await getIbcLcdClient(restEndpoint);
       // note: it appears that clients may appear in this list if they are of:
@@ -104,56 +132,141 @@ function useIbcClientStates(chain: Chain) {
       //           using GET/ibc/core/client/v1/client_status/07-tendermint-0)
       // we ignore the status of the light clients here, but their status should
       // be checked at the moment they are required for a transfer
+      const params: QueryClientStatesRequest = {
+        pagination: {
+          key,
+          count_total: !key,
+        },
+      };
       return (
-        lcd?.ibc.core.client.v1.clientStates() ?? {
+        lcd?.ibc.core.client.v1.clientStates(params) ?? {
           client_states: [],
-          pagination: { total: Long.ZERO },
+          pagination: {
+            total: Long.ZERO,
+          },
         }
       );
     },
+    defaultPageParam: undefined,
+    getNextPageParam: (lastPage): Uint8Array | undefined => {
+      // don't pass an empty array as that will trigger another page to download
+      return lastPage?.pagination?.next_key?.length
+        ? lastPage.pagination.next_key
+        : undefined;
+    },
     refetchInterval: 5 * minutes,
     refetchOnMount: false,
+    staleTime: Number.POSITIVE_INFINITY,
   });
+
+  // fetch all pages
+  useFetchAllPaginatedPages(results);
+
+  // combine all data pages
+  const data = useMemo(
+    () => results.data?.pages.flatMap((page) => page.client_states),
+    [results.data?.pages]
+  );
+
+  return { ...results, data };
 }
 
 function useIbcConnections(chain: Chain) {
   const { data: restEndpoint } = useRemoteChainRestEndpoint(chain);
-  return useQuery({
+  const results = useInfiniteQuery({
     queryKey: ['ibc-connections', restEndpoint],
-    queryFn: async (): Promise<QueryConnectionsResponse> => {
+    queryFn: async ({
+      pageParam: key,
+    }: {
+      pageParam?: Uint8Array;
+    }): Promise<QueryConnectionsResponse> => {
       // get IBC LCD client
       const lcd = await getIbcLcdClient(restEndpoint);
+      const params: QueryConnectionsRequest = {
+        pagination: {
+          key,
+          count_total: !key,
+        },
+      };
       return (
-        lcd?.ibc.core.connection.v1.connections() ?? {
+        lcd?.ibc.core.connection.v1.connections(params) ?? {
           connections: [],
           pagination: { total: Long.ZERO },
           height: { revision_height: Long.ZERO, revision_number: Long.ZERO },
         }
       );
     },
+    defaultPageParam: undefined,
+    getNextPageParam: (lastPage): Uint8Array | undefined => {
+      // don't pass an empty array as that will trigger another page to download
+      return lastPage?.pagination?.next_key?.length
+        ? lastPage.pagination.next_key
+        : undefined;
+    },
     refetchInterval: 5 * minutes,
     refetchOnMount: false,
+    staleTime: Number.POSITIVE_INFINITY,
   });
+
+  // fetch all pages
+  useFetchAllPaginatedPages(results);
+
+  // combine all data pages
+  const data = useMemo(
+    () => results.data?.pages.flatMap((page) => page.connections),
+    [results.data?.pages]
+  );
+
+  return { ...results, data };
 }
 
 function useIbcChannels(chain: Chain) {
   const { data: restEndpoint } = useRemoteChainRestEndpoint(chain);
-  return useQuery({
+  const results = useInfiniteQuery({
     queryKey: ['ibc-channels', restEndpoint],
-    queryFn: async (): Promise<QueryChannelsResponse> => {
+    queryFn: async ({
+      pageParam: key,
+    }: {
+      pageParam?: Uint8Array;
+    }): Promise<QueryChannelsResponse> => {
       // get IBC LCD client
       const lcd = await getIbcLcdClient(restEndpoint);
+      const params: QueryChannelsRequest = {
+        pagination: {
+          key,
+          count_total: !key,
+        },
+      };
       return (
-        lcd?.ibc.core.channel.v1.channels() ?? {
+        lcd?.ibc.core.channel.v1.channels(params) ?? {
           channels: [],
           pagination: { total: Long.ZERO },
           height: { revision_height: Long.ZERO, revision_number: Long.ZERO },
         }
       );
     },
+    defaultPageParam: undefined,
+    getNextPageParam: (lastPage): Uint8Array | undefined => {
+      // don't pass an empty array as that will trigger another page to download
+      return lastPage?.pagination?.next_key?.length
+        ? lastPage.pagination.next_key
+        : undefined;
+    },
     refetchInterval: 5 * minutes,
     refetchOnMount: false,
+    staleTime: Number.POSITIVE_INFINITY,
   });
+
+  // fetch all pages
+  useFetchAllPaginatedPages(results);
+
+  // combine all data pages
+  const data = useMemo(
+    () => results.data?.pages.flatMap((page) => page.channels),
+    [results.data?.pages]
+  );
+
+  return { ...results, data };
 }
 
 function filterConnectionsOpen(
@@ -169,13 +282,10 @@ function filterChannelsOpen(
 }
 
 export function useIbcOpenTransfers(chain: Chain = dualityChain) {
-  const { data: clientStateData } = useIbcClientStates(chain);
-  const { data: connectionData } = useIbcConnections(chain);
-  const { data: channelData } = useIbcChannels(chain);
+  const { data: clientStates } = useIbcClientStates(chain);
+  const { data: connections } = useIbcConnections(chain);
+  const { data: channels } = useIbcChannels(chain);
 
-  const clientStates = useDeepCompareMemoize(clientStateData?.client_states);
-  const connections = useDeepCompareMemoize(connectionData?.connections);
-  const channels = useDeepCompareMemoize(channelData?.channels);
   return useMemo(() => {
     // get openClients (all listed clients are assumed to be working)
     const openClients = clientStates || [];

--- a/src/lib/web3/hooks/useChains.ts
+++ b/src/lib/web3/hooks/useChains.ts
@@ -1,5 +1,5 @@
 import { Chain } from '@chain-registry/types';
-import { useEffect, useMemo } from 'react';
+import { useMemo } from 'react';
 import { ibc, router } from '@duality-labs/dualityjs';
 import { QueryParamsResponse as QueryRouterParams } from '@duality-labs/dualityjs/types/codegen/router/v1/query';
 import { Params as QueryConnectionParams } from '@duality-labs/dualityjs/types/codegen/ibc/core/connection/v1/connection';
@@ -18,16 +18,13 @@ import {
 import { QueryBalanceResponse } from '@duality-labs/dualityjs/types/codegen/cosmos/bank/v1beta1/query';
 import { State as ChannelState } from '@duality-labs/dualityjs/types/codegen/ibc/core/channel/v1/channel';
 import { State as ConnectionState } from '@duality-labs/dualityjs/types/codegen/ibc/core/connection/v1/connection';
-import {
-  UseInfiniteQueryResult,
-  useInfiniteQuery,
-  useQuery,
-} from '@tanstack/react-query';
+import { useInfiniteQuery, useQuery } from '@tanstack/react-query';
 
 import { getChainInfo } from '../wallets/keplr';
 import dualityLogo from '../../../assets/logo/logo.svg';
 import { Token, getTokenId } from '../utils/tokens';
 import { minutes } from '../../utils/time';
+import { useFetchAllPaginatedPages } from './useQueries';
 import Long from 'long';
 
 interface QueryConnectionParamsResponse {
@@ -101,18 +98,6 @@ async function getIbcLcdClient(
   if (restEndpoint) {
     return ibc.ClientFactory.createLCDClient({ restEndpoint });
   }
-}
-
-function useFetchAllPaginatedPages(results: UseInfiniteQueryResult) {
-  const { fetchNextPage, isFetchingNextPage, hasNextPage } = results;
-  // fetch more data if data has changed but there are still more pages to get
-  useEffect(() => {
-    if (hasNextPage && !isFetchingNextPage) {
-      // cancelRefetch will create a new request for each hook
-      // and should not be done here because this is an effect not a user action
-      fetchNextPage({ cancelRefetch: false });
-    }
-  }, [fetchNextPage, isFetchingNextPage, hasNextPage]);
 }
 
 function useIbcClientStates(chain: Chain) {

--- a/src/lib/web3/hooks/useQueries.ts
+++ b/src/lib/web3/hooks/useQueries.ts
@@ -1,0 +1,15 @@
+import { useEffect } from 'react';
+
+import { UseInfiniteQueryResult } from '@tanstack/react-query';
+
+export function useFetchAllPaginatedPages(results: UseInfiniteQueryResult) {
+  const { fetchNextPage, isFetchingNextPage, hasNextPage } = results;
+  // fetch more data if data has changed but there are still more pages to get
+  useEffect(() => {
+    if (hasNextPage && !isFetchingNextPage) {
+      // cancelRefetch will create a new request for each hook
+      // and should not be done here because this is an effect not a user action
+      fetchNextPage({ cancelRefetch: false });
+    }
+  }, [fetchNextPage, isFetchingNextPage, hasNextPage]);
+}

--- a/src/lib/web3/hooks/useUserBankBalances.ts
+++ b/src/lib/web3/hooks/useUserBankBalances.ts
@@ -17,6 +17,7 @@ import { useWeb3 } from '../useWeb3';
 import { isDexShare } from '../utils/shares';
 import { MessageActionEvent, TendermintTxData } from '../events';
 import { CoinTransferEvent, mapEventAttributes } from '../utils/events';
+import { useFetchAllPaginatedPages } from './useQueries';
 
 // fetch all the user's bank balance
 function useAllUserBankBalances(): UseQueryResult<Coin[]> {
@@ -91,13 +92,8 @@ function useAllUserBankBalances(): UseQueryResult<Coin[]> {
     }
   }, [refetch, address]);
 
-  const { fetchNextPage, data, hasNextPage } = result;
-  // fetch more data if data has changed but there are still more pages to get
-  useEffect(() => {
-    if (fetchNextPage && hasNextPage) {
-      fetchNextPage();
-    }
-  }, [fetchNextPage, data, hasNextPage]);
+  // fetch all pages
+  useFetchAllPaginatedPages(result);
 
   // combine all non-zero balances
   const pages = result.data?.pages;

--- a/src/lib/web3/hooks/useUserDeposits.ts
+++ b/src/lib/web3/hooks/useUserDeposits.ts
@@ -11,6 +11,7 @@ import { TokenIdPair, TokenPair, resolveTokenIdPair } from '../utils/tokens';
 import { minutes } from '../../utils/time';
 import { useDexRestClientPromise } from '../clients/restClients';
 import { QueryAllUserDepositsResponse } from '@duality-labs/dualityjs/types/codegen/duality/dex/query';
+import { useFetchAllPaginatedPages } from './useQueries';
 
 function useAllUserDeposits(): UseQueryResult<DepositRecord[]> {
   const { address } = useWeb3();
@@ -46,13 +47,8 @@ function useAllUserDeposits(): UseQueryResult<DepositRecord[]> {
     refetchInterval: 5 * minutes,
   });
 
-  const { refetch, fetchNextPage, data, hasNextPage } = result;
-  // fetch more data if data has changed but there are still more pages to get
-  useEffect(() => {
-    if (fetchNextPage && hasNextPage) {
-      fetchNextPage();
-    }
-  }, [fetchNextPage, data, hasNextPage]);
+  // fetch all pages
+  useFetchAllPaginatedPages(result);
 
   // combine all deposits and sort them
   const userDeposits = useMemo(() => {
@@ -64,6 +60,8 @@ function useAllUserDeposits(): UseQueryResult<DepositRecord[]> {
           b.fee.sub(a.fee).toNumber()
       );
   }, [result.data]);
+
+  const { refetch } = result;
 
   // on update to user's bank balance, we should update the user's sharesOwned
   useEffect(() => {


### PR DESCRIPTION
This PR aims to clean up some fixes before merging:
- #516 

In particular this PR refactors cleans up several small issues identified during the main PR to merge after

- fixed: change IBC data fetch hooks to download all pages of data, instead of just one page
- a helper from the above fix is used in several places to simplify the loading of all pages for other resources