### PR TITLE
feat!: allow major & minor versions to be changed with Semantic Release

### DIFF
--- a/release.config.cjs
+++ b/release.config.cjs
@@ -15,8 +15,8 @@ module.exports = {
         // see default rules: https://github.com/semantic-release/commit-analyzer/blob/master/lib/default-release-rules.js
         releaseRules: [
           // while in "alpha" mode don't increment the major version
-          { breaking: true, release: 'minor' },
-          { type: 'feat', release: 'patch' },
+          { breaking: true, release: 'major' },
+          { type: 'feat', release: 'minor' },
           { type: 'fix', release: 'patch' },
           { type: 'perf', release: 'patch' },
         ],


### PR DESCRIPTION
This PR indicates the changing of the Duality web app from beta versioning (0.x.x) to production semantic releases (x.x.x).

The intention is to keep the major versions of the web app in line with the major versions of the releases of the native chain:
  - https://github.com/neutron-org/neutron/releases

The beta versioning was intended to stay in line with the previous native chain of:
  - https://github.com/duality-labs/duality/releases

However, the upgrade commits of v0.4.0 and v0.5.0 were missed in the following PRs:
- v0.4.0: #496 
- v0.5.0: #499

This release (v1.0.0) represents the last version of the web app to work on the Duality chain. The next version (v2.0.0) will target using the Duality dex on Neutron API v2.0.0.

---

BREAKING CHANGE: This PR upgrades the app to use major version releases