### PR TITLE
fix: Update testnet chain endpoints

### DIFF
--- a/.env
+++ b/.env
@@ -25,9 +25,9 @@ REACT_APP__MAX_FRACTION_DIGITS=18
 REACT_APP__MAX_TICK_INDEXES=-352437,352437
 
 REACT_APP__INDEXER_API=https://indexer.testnet-1.duality.xyz
-REACT_APP__REST_API=https://rest-lb-pion.ntrn.tech
-REACT_APP__RPC_API=https://rpc-lb-pion.ntrn.tech
-REACT_APP__WEBSOCKET_URL=wss://rpc-lb-pion.ntrn.tech/websocket
+REACT_APP__REST_API=https://rest-falcron.pion-1.ntrn.tech
+REACT_APP__RPC_API=https://rpc-falcron.pion-1.ntrn.tech
+REACT_APP__WEBSOCKET_URL=wss://rpc-falcron.pion-1.ntrn.tech/websocket
 REACT_APP__WEBSOCKET_SUBSCRIPTION_LIMIT=5
 
 # Default Analytics as empty

--- a/.env
+++ b/.env
@@ -24,6 +24,9 @@ REACT_APP__MAX_FRACTION_DIGITS=18
 # link: https://github.com/duality-labs/duality/commit/377592adb4ac0ef445c5e2bc2a73e2635189ccfc
 REACT_APP__MAX_TICK_INDEXES=-352437,352437
 
+# Chain endpoints: the latest information should be at
+# - mainnet: https://github.com/cosmos/chain-registry/blob/master/neutron/chain.json
+# - testnet: https://github.com/cosmos/chain-registry/blob/master/testnets/neutrontestnet/chain.json
 REACT_APP__INDEXER_API=https://indexer.testnet-1.duality.xyz
 REACT_APP__REST_API=https://rest-falcron.pion-1.ntrn.tech
 REACT_APP__RPC_API=https://rpc-falcron.pion-1.ntrn.tech


### PR DESCRIPTION
This PR updates the chain endpoints of the deployed https://app.testnet.duality.xyz build and the deploy preview builds to newer (and running) chain endpoints