### PR TITLE
feat: improve Orderbook page UI

### DIFF
--- a/src/components/cards/LimitOrderCard.scss
+++ b/src/components/cards/LimitOrderCard.scss
@@ -49,7 +49,7 @@
     }
   }
 
-  .token-amount-input {
+  .numeric-value-input {
     color: hsl(218deg, 11%, 65%);
     background-color: hsla(216, 20%, 25%, 1);
     border: 1px solid var(--page-card-border);
@@ -61,6 +61,15 @@
       text-align: right;
       flex: 1 1 auto;
       width: 80px;
+      // disable spin buttons on desktop
+      &::-webkit-outer-spin-button,
+      &::-webkit-inner-spin-button {
+        display: none; /* Webkit/Safari/Chrome/Edge */
+      }
+      &[type='number'] {
+        appearance: textfield;
+        -moz-appearance: textfield; /* Firefox */
+      }
     }
     // fix vertical alignment
     align-items: baseline;

--- a/src/components/cards/LimitOrderCard.tsx
+++ b/src/components/cards/LimitOrderCard.tsx
@@ -603,15 +603,16 @@ function NumericInputRow({
 
   return (
     <div
-      className={['token-amount-input flex row py-3 px-4', className]
+      className={['numeric-value-input flex row py-3 px-4', className]
         .filter(Boolean)
         .join(' ')}
     >
       {prefix && (
-        <div className="token-amount-input__prefix mr-3">{prefix}</div>
+        <div className="numeric-value-input__prefix mr-3">{prefix}</div>
       )}
       <input
-        className="token-amount-input__input flex"
+        type="number"
+        className="numeric-value-input__input flex"
         placeholder="0"
         value={internalValue}
         onInput={() => maybeUpdate(inputRef.current?.value || '0', onInput)}
@@ -624,7 +625,7 @@ function NumericInputRow({
         style={readOnly ? { outline: 'none' } : undefined}
       ></input>
       {suffix && (
-        <div className="token-amount-input__suffix ml-3">{suffix}</div>
+        <div className="numeric-value-input__suffix ml-3">{suffix}</div>
       )}
     </div>
   );

--- a/src/lib/web3/hooks/useIndexer.ts
+++ b/src/lib/web3/hooks/useIndexer.ts
@@ -170,18 +170,18 @@ export class IndexerStream<DataRow = BaseDataRow> {
         do {
           // create new URL that can be mutated without mutating original URL
           const loopURL = new URL(url);
+          // add next page key if not all data was returned by last request
+          if (nextKey) {
+            loopURL.searchParams.set('pagination.key', nextKey);
+          }
           // overwrite block height to request from (to long-poll next update)
           // note: known height is usually the chain height so the request
           //       will be answered when the next block of data is available)
-          if (isRealtimeRequest && knownHeight) {
+          else if (isRealtimeRequest && knownHeight) {
             loopURL.searchParams.set(
               'block_range.from_height',
               knownHeight.toFixed()
             );
-          }
-          // add next page key if not all data was returned by last request
-          if (nextKey) {
-            loopURL.searchParams.set('pagination.key', nextKey);
           }
           const response = await fetch(loopURL.toString(), fetchOptions);
           if (response.status === 200) {

--- a/src/lib/web3/hooks/useIndexer.ts
+++ b/src/lib/web3/hooks/useIndexer.ts
@@ -9,7 +9,7 @@ type value = string | number;
 type BaseDataRow = FlattenSingularItems<[id: value, values: value | value[]]>;
 type BaseDataSet<DataRow extends BaseDataRow> = Map<DataRow['0'], DataRow['1']>;
 
-type IndexerPage<DataRow = BaseDataRow> = {
+export type IndexerPage<DataRow = BaseDataRow> = {
   shape:
     | [[string, string | string[]]]
     | [[[string, string | string[]]], [[string, string | string[]]]];

--- a/src/lib/web3/hooks/useIndexer.ts
+++ b/src/lib/web3/hooks/useIndexer.ts
@@ -168,20 +168,22 @@ export class IndexerStream<DataRow = BaseDataRow> {
         let retries = 0;
         let nextKey: string | undefined = undefined;
         do {
+          // create new URL that can be mutated without mutating original URL
+          const loopURL = new URL(url);
           // overwrite block height to request from (to long-poll next update)
           // note: known height is usually the chain height so the request
           //       will be answered when the next block of data is available)
           if (isRealtimeRequest && knownHeight) {
-            url.searchParams.set(
+            loopURL.searchParams.set(
               'block_range.from_height',
               knownHeight.toFixed()
             );
           }
           // add next page key if not all data was returned by last request
           if (nextKey) {
-            url.searchParams.set('pagination.key', nextKey);
+            loopURL.searchParams.set('pagination.key', nextKey);
           }
-          const response = await fetch(url.toString(), fetchOptions);
+          const response = await fetch(loopURL.toString(), fetchOptions);
           if (response.status === 200) {
             const {
               data = [],

--- a/src/lib/web3/hooks/useIndexer.ts
+++ b/src/lib/web3/hooks/useIndexer.ts
@@ -153,6 +153,11 @@ export class IndexerStream<DataRow = BaseDataRow> {
     const fetchOptions = { signal: this.abortController.signal };
     try {
       let knownHeight = 0;
+      // check for desired real-time: if query is open ended to the future
+      const isRealtimeRequest = !(
+        Number(url.searchParams.get('pagination.before')) ||
+        Number(url.searchParams.get('block_range.to_height'))
+      );
       // hack/fix: to control time limit behavior, assume the before timestamp
       //           is in the past as we can't candle future timestamp limits
       const toHeight = url.searchParams.get('pagination.before')
@@ -166,7 +171,7 @@ export class IndexerStream<DataRow = BaseDataRow> {
           // overwrite block height to request from (to long-poll next update)
           // note: known height is usually the chain height so the request
           //       will be answered when the next block of data is available)
-          if (knownHeight) {
+          if (isRealtimeRequest && knownHeight) {
             url.searchParams.set(
               'block_range.from_height',
               knownHeight.toFixed()

--- a/src/lib/web3/hooks/useIndexer.ts
+++ b/src/lib/web3/hooks/useIndexer.ts
@@ -513,9 +513,15 @@ async function fetchDataFromIndexer<DataRow extends BaseDataRow>(
 ): Promise<BaseDataSet<DataRow> | BaseDataSet<DataRow>[]> {
   return new Promise((resolve, reject) => {
     const url = new URL(baseURL, REACT_APP__INDEXER_API);
-    // set max height to now, which will cause the request to end at now height
-    const before = Date.now() / 1000;
-    url.searchParams.append('pagination.before', before.toFixed(0));
+    // limit max height to stop the request from streaming realtime updates
+    const isRealtimeRequest = !(
+      Number(url.searchParams.get('pagination.before')) ||
+      Number(url.searchParams.get('block_range.to_height'))
+    );
+    if (isRealtimeRequest) {
+      const before = Date.now() / 1000;
+      url.searchParams.append('pagination.before', before.toFixed(0));
+    }
     // add stream listener and resolve promise on completion
     const stream = new IndexerClass<DataRow>(
       url,

--- a/src/lib/web3/hooks/useTokens.ts
+++ b/src/lib/web3/hooks/useTokens.ts
@@ -74,8 +74,11 @@ export function useDenomFromPathParam(
       return undefined;
     }
     const tokens = Array.from(tokenByDenom?.values() ?? []);
-    // return denom of resolved token, or the passed param which may be a denom
-    return tokens.find(matchTokenBySymbol(pathParam))?.base ?? pathParam;
+    // return denom of resolved token
+    // note: to use passed param as a backup denom, use property expansion, eg.
+    //       const { data: denomA = match?.params['tokenA'] }
+    //         = useDenomFromPathParam(match?.params['tokenA']);
+    return tokens.find(matchTokenBySymbol(pathParam))?.base;
   }, [tokenByDenom, pathParam]);
   return useSwrResponse(denom, swr);
 }

--- a/src/pages/Orderbook/Orderbook.tsx
+++ b/src/pages/Orderbook/Orderbook.tsx
@@ -27,7 +27,6 @@ export default function OrderbookPage() {
 function Orderbook() {
   // change tokens to match pathname
   const match = useMatch('/orderbook/:tokenA/:tokenB');
-  // need to add some sort of opt-out flag, allow resolving a denom only if it is found in a registry?
   const { data: denomA } = useDenomFromPathParam(match?.params['tokenA']);
   const { data: denomB } = useDenomFromPathParam(match?.params['tokenB']);
   const { data: tokenA } = useToken(denomA);
@@ -41,11 +40,9 @@ function Orderbook() {
       <div className="orderbook-body row gap-3">
         <div className="flex col">
           <div className="flex page-card">
-            {tokenA &&
-              tokenB &&
-              `${denomA}${denomB}` === `${denomA}${denomB}`.toLowerCase() && (
-                <OrderBookChart tokenA={tokenA} tokenB={tokenB} />
-              )}
+            {tokenA && tokenB && (
+              <OrderBookChart tokenA={tokenA} tokenB={tokenB} />
+            )}
           </div>
         </div>
         <div className="col">

--- a/src/pages/Orderbook/Orderbook.tsx
+++ b/src/pages/Orderbook/Orderbook.tsx
@@ -27,6 +27,7 @@ export default function OrderbookPage() {
 function Orderbook() {
   // change tokens to match pathname
   const match = useMatch('/orderbook/:tokenA/:tokenB');
+  // need to add some sort of opt-out flag, allow resolving a denom only if it is found in a registry?
   const { data: denomA } = useDenomFromPathParam(match?.params['tokenA']);
   const { data: denomB } = useDenomFromPathParam(match?.params['tokenB']);
   const { data: tokenA } = useToken(denomA);
@@ -40,9 +41,11 @@ function Orderbook() {
       <div className="orderbook-body row gap-3">
         <div className="flex col">
           <div className="flex page-card">
-            {tokenA && tokenB && (
-              <OrderBookChart tokenA={tokenA} tokenB={tokenB} />
-            )}
+            {tokenA &&
+              tokenB &&
+              `${denomA}${denomB}` === `${denomA}${denomB}`.toLowerCase() && (
+                <OrderBookChart tokenA={tokenA} tokenB={tokenB} />
+              )}
           </div>
         </div>
         <div className="col">

--- a/src/pages/Orderbook/OrderbookChart.tsx
+++ b/src/pages/Orderbook/OrderbookChart.tsx
@@ -35,6 +35,7 @@ const defaultWidgetOptions: Partial<ChartingLibraryWidgetOptions> = {
   charts_storage_api_version: '1.1',
   // path to static assets of the charting library
   library_path: '/charting_library/',
+  theme: 'dark',
 };
 
 interface RequestQuery {

--- a/src/pages/Orderbook/OrderbookChart.tsx
+++ b/src/pages/Orderbook/OrderbookChart.tsx
@@ -20,6 +20,7 @@ import useTokenPairs from '../../lib/web3/hooks/useTokenPairs';
 import { tickIndexToPrice } from '../../lib/web3/utils/ticks';
 import { TimeSeriesRow } from '../../components/stats/utils';
 import { IndexerStreamAccumulateSingleDataSet } from '../../lib/web3/hooks/useIndexer';
+import { days, hours, minutes, seconds } from '../../lib/utils/time';
 
 const { REACT_APP__INDEXER_API = '', PROD } = import.meta.env;
 
@@ -120,10 +121,19 @@ export default function OrderBookChart({
       '1D': 'day', // day
     };
 
+    const resolutionInMsMap: {
+      [tradingViewResolution: string]: number;
+    } = {
+      '1S': 1 * seconds,
+      '1': 1 * minutes,
+      '60': 1 * hours,
+      '1D': 1 * days,
+    };
+
     // keep track of data subscription state here
     type FetchID = string;
     type SubscriberUUID = string;
-    const knownTimestamps: Map<FetchID, number> = new Map();
+    const lastBars: Map<FetchID, Bar> = new Map();
     const knownHeights: Map<FetchID, number> = new Map();
     const streams: Map<
       SubscriberUUID,
@@ -266,15 +276,34 @@ export default function OrderBookChart({
                 onCompleted: (data, height) => {
                   stream.unsubscribe();
                   knownHeights.set(fetchID, height);
-                  const bars: Bar[] = Array.from(data)
-                    // note: the data needs to be in chronological order
-                    // and our API delivers results in reverse-chronological order
-                    .reverse()
-                    .map(getBarFromTimeSeriesRow);
-                  // record most recent time stamp of this fetch
-                  const lastTimestamp = bars.at(-1)?.time;
-                  if (lastTimestamp) {
-                    knownTimestamps.set(fetchID, lastTimestamp);
+                  const resolutionInMs = resolutionInMsMap[resolution];
+                  const bars: Bar[] = Array.from(data).reduceRight<Bar[]>(
+                    (acc, data) => {
+                      const bar = getBarFromTimeSeriesRow(data);
+                      // fill in any gaps with the last close price
+                      const lastBar = acc[acc.length - 1];
+                      const extraBars: Bar[] = [];
+                      if (lastBar && resolutionInMs) {
+                        let lastTimestamp = lastBar.time;
+                        while (lastTimestamp + resolutionInMs < bar.time) {
+                          lastTimestamp += resolutionInMs;
+                          extraBars.push({
+                            time: lastTimestamp,
+                            open: lastBar.close,
+                            high: lastBar.close,
+                            low: lastBar.close,
+                            close: lastBar.close,
+                          });
+                        }
+                      }
+                      return [...acc, ...extraBars, bar];
+                    },
+                    []
+                  );
+                  // record most recent bar info of this fetch
+                  const lastBar = bars.at(-1);
+                  if (lastBar) {
+                    lastBars.set(fetchID, lastBar);
                   }
                   onHistoryCallback(bars, { noData: !bars.length });
                 },
@@ -303,18 +332,37 @@ export default function OrderBookChart({
           const stream =
             new IndexerStreamAccumulateSingleDataSet<TimeSeriesRow>(url, {
               onUpdate: (dataUpdates) => {
-                const lastTimestamp = knownTimestamps.get(fetchID);
+                let lastBar = lastBars.get(fetchID);
+                const resolutionInMs = resolutionInMsMap[resolution];
                 // note: the data needs to be in chronological order
                 // and our API delivers results in reverse-chronological order
                 const chronologicalUpdates = dataUpdates.reverse();
                 for (const row of chronologicalUpdates) {
                   const bar = getBarFromTimeSeriesRow(row);
+                  // add extra empty bars if there would be a gap in time
+                  if (lastBar && resolutionInMs) {
+                    let lastTimestamp = lastBar.time;
+                    while (lastTimestamp + resolutionInMs < bar.time) {
+                      lastTimestamp += resolutionInMs;
+                      onRealtimeCallback({
+                        time: lastTimestamp,
+                        open: lastBar.close,
+                        high: lastBar.close,
+                        low: lastBar.close,
+                        close: lastBar.close,
+                      });
+                    }
+                  }
                   // add only bars that are new or updates to last timestamp
-                  if (!lastTimestamp || bar.time >= lastTimestamp) {
+                  if (!lastBar || bar.time >= lastBar.time) {
                     onRealtimeCallback(bar);
                   }
-                  // record last timestamp
-                  knownTimestamps.set(fetchID, bar.time);
+                  // record last timestamp (to state, and shortcut in-loop var)
+                  lastBar = bar;
+                }
+                // record last bar to state
+                if (lastBar) {
+                  lastBars.set(fetchID, lastBar);
                 }
               },
               onError: (e) => {

--- a/src/pages/Orderbook/OrderbookChart.tsx
+++ b/src/pages/Orderbook/OrderbookChart.tsx
@@ -278,7 +278,9 @@ export default function OrderBookChart({
               {
                 onCompleted: (data, height) => {
                   stream.unsubscribe();
-                  knownHeights.set(fetchID, height);
+                  if (height > (knownHeights.get(fetchID) ?? 0)) {
+                    knownHeights.set(fetchID, height);
+                  }
                   const resolutionInMs = resolutionInMsMap[resolution];
                   const bars: Bar[] = Array.from(data).reduceRight<Bar[]>(
                     (acc, data) => {
@@ -305,7 +307,10 @@ export default function OrderBookChart({
                   );
                   // record most recent bar info of this fetch
                   const lastBar = bars.at(-1);
-                  if (lastBar) {
+                  if (
+                    lastBar &&
+                    lastBar.time > (lastBars.get(fetchID)?.time ?? 0)
+                  ) {
                     lastBars.set(fetchID, lastBar);
                   }
                   onHistoryCallback(bars, { noData: !bars.length });

--- a/src/pages/Orderbook/OrderbookChart.tsx
+++ b/src/pages/Orderbook/OrderbookChart.tsx
@@ -11,6 +11,7 @@ import {
   LibrarySymbolInfo,
   SearchSymbolResultItem,
   Bar,
+  Timezone,
 } from 'charting_library';
 
 import { Token, getTokenId } from '../../lib/web3/utils/tokens';
@@ -29,6 +30,7 @@ const defaultWidgetOptions: Partial<ChartingLibraryWidgetOptions> = {
   autosize: true,
   container: '',
   locale: 'en',
+  timezone: Intl.DateTimeFormat().resolvedOptions().timeZone as Timezone,
   disabled_features: ['use_localstorage_for_settings'],
   enabled_features: ['study_templates'],
   charts_storage_url: 'https://saveload.tradingview.com',

--- a/src/pages/Orderbook/OrderbookChart.tsx
+++ b/src/pages/Orderbook/OrderbookChart.tsx
@@ -313,7 +313,12 @@ export default function OrderBookChart({
                   ) {
                     lastBars.set(fetchID, lastBar);
                   }
-                  onHistoryCallback(bars, { noData: !bars.length });
+                  // note: don't claim "noData" unless you can be sure there is
+                  //       no more data. if the first page of data (5 hours)
+                  //       is empty and we declare "noData", it will not query
+                  //       for the next time period (the 5 hours before that)
+                  // todo: possibly add "most_recent_timestamp" data in indexer
+                  onHistoryCallback(bars, { noData: undefined });
                 },
                 onError: (e) => {
                   onErrorCallback(


### PR DESCRIPTION
This PR cleans up parts of the Orderbook page UI

- Orderbook Charts:
  - prevent "out of order data" errors by preventing updates with duplicate old data points
  - prevent "time jump" issues by filling in blank periods of no activity with the close of the last price
  - prevent incorrect indexer data requests from being sent while token denoms are still resolving
  - use dark theme as default color scheme
  - fix timezone displayed on Chart to timezone detected in browser
  - fix issue where if no recent data was found, the chart would cease queries for older data
  - fixed priority and mutation of indexer query params: `nextKey` page requests should not accept extra new params

- Orderbook List (close-to-price liquidity buckets table) card:
  - fix the calculation of liquidity bucket amounts when token pair is in inverted order
  
- Orderbook Limit Order card:
  - prevent LastPass from trying to fill the numeric "amount" field with saved passwords