### PR TITLE
fix: improve display of factory tokens (such as wstETH)

### DIFF
--- a/src/components/cards/PoolsTableCard.tsx
+++ b/src/components/cards/PoolsTableCard.tsx
@@ -447,7 +447,7 @@ function TokenPair({
         </div>
         <div className="row">
           <div className="col subtext text-left">
-            {token0.chain.chain_name === token1.chain.chain_name ? (
+            {token0.chain.pretty_name === token1.chain.pretty_name ? (
               <span className="nowrap">{token0.chain.pretty_name}</span>
             ) : (
               <>

--- a/src/lib/web3/hooks/useDenomClients.ts
+++ b/src/lib/web3/hooks/useDenomClients.ts
@@ -41,8 +41,6 @@ type AssetByDenom = Map<string, Asset>;
 type AssetClientByDenom = Map<string, ChainRegistryClient>;
 type AssetChainUtilByDenom = Map<string, ChainRegistryChainUtil>;
 
-const concurrentItemCount = 3;
-
 // export hook for getting ChainRegistryClient instances for each denom
 export function useAssetClientByDenom(
   denoms: string[] = []
@@ -63,30 +61,23 @@ export function useAssetClientByDenom(
     (index: number) => {
       const denom = uniqueDenoms.at(index);
       const trace = denom ? denomTraceByDenom?.get(denom) : undefined;
-      // note: you might expect that because the page size is 3
-      //       that 3 keys will be evaluated to see if they have changed,
-      //       but only 1 key will be evaluated. if the first key has no change
-      //       then no other keys will be evaluated and fetch will not be called.
-      // todo: refactoring with a dynamic list of useQueries may solve this.
-      //       for now, ensure the key is different if more traces are available.
-      const traceKeys = Array.from(denomTraceByDenom?.keys() ?? []);
-      return denom ? [denom, trace, `asset-client-${traceKeys}`] : null;
+      return denom ? [denom, trace, 'asset-client'] : null;
     },
     async ([denom, trace]) => {
       return [denom, await getAssetClient(denom, trace)];
     },
     {
       parallel: true,
+      initialSize: 1,
       use: [immutable],
-      initialSize: concurrentItemCount,
     }
   );
 
-  // get all pages, concurrentItemCount at a time
+  // get all pages, resolving one key at a time
   const { size, setSize } = swr2;
   useEffect(() => {
     if (size < uniqueDenoms.length) {
-      setSize((s) => Math.min(uniqueDenoms.length, s + concurrentItemCount));
+      setSize((s) => Math.min(uniqueDenoms.length, s + 1));
     }
   }, [size, setSize, uniqueDenoms]);
 

--- a/src/lib/web3/hooks/useDenomClients.ts
+++ b/src/lib/web3/hooks/useDenomClients.ts
@@ -70,6 +70,8 @@ export function useAssetClientByDenom(
       parallel: true,
       initialSize: 1,
       use: [immutable],
+      revalidateFirstPage: false,
+      revalidateAll: false,
     }
   );
 

--- a/src/lib/web3/hooks/useDenomClients.ts
+++ b/src/lib/web3/hooks/useDenomClients.ts
@@ -58,13 +58,15 @@ export function useAssetClientByDenom(
       [denom: string, trace: DenomTrace | undefined, key: string] | null
     >
   >(
+    // allow hash to be an empty string
     (index: number) => {
       const denom = uniqueDenoms.at(index);
       const trace = denom ? denomTraceByDenom?.get(denom) : undefined;
-      return denom ? [denom, trace, 'asset-client'] : null;
+      return [denom || '', trace, 'asset-client'];
     },
+    // handle cases of empty hash string
     async ([denom, trace]) => {
-      return [denom, await getAssetClient(denom, trace)];
+      return [denom, denom ? await getAssetClient(denom, trace) : undefined];
     },
     {
       parallel: true,
@@ -79,7 +81,7 @@ export function useAssetClientByDenom(
   const { size, setSize } = swr2;
   useEffect(() => {
     if (size < uniqueDenoms.length) {
-      setSize((s) => Math.min(uniqueDenoms.length, s + 1));
+      setSize((size) => Math.min(uniqueDenoms.length, size + 1));
     }
   }, [size, setSize, uniqueDenoms]);
 

--- a/src/lib/web3/hooks/useDenomsFromChain.ts
+++ b/src/lib/web3/hooks/useDenomsFromChain.ts
@@ -16,8 +16,6 @@ type SWRCommon<Data = unknown, Error = unknown> = {
   data: Data | undefined;
 };
 
-const concurrentItemCount = 3;
-
 export function useDenomTraceByDenom(
   denoms: string[]
 ): SWRCommon<DenomTraceByDenom> {
@@ -62,19 +60,19 @@ export function useDenomTraceByDenom(
     // these endpoint responses never change
     {
       parallel: true,
+      initialSize: 1,
       use: [immutable],
-      initialSize: concurrentItemCount,
       revalidateFirstPage: false,
       revalidateAll: false,
       errorRetryCount: 3,
     }
   );
 
-  // get all pages, concurrentItemCount at a time
+  // get all pages, resolving one key at a time
   const { size, setSize } = swr;
   useEffect(() => {
     if (size < ibcDenoms.length) {
-      setSize((size) => Math.min(ibcDenoms.length, size + concurrentItemCount));
+      setSize((size) => Math.min(ibcDenoms.length, size + 1));
     }
   }, [size, setSize, ibcDenoms]);
 


### PR DESCRIPTION
this PR:
- fixes a bug where factory tokens (such as wstETH that represent a token from another chain) would not display the name of that chain on Pools tables (and instead would display the native chain name)
- fixes a bug where Asset info objects may not be resolved due to cached fetch pagination results from before the denom was asked for

todo (as a separate task):
- show IBC tokens that are not resolved by chain-registry data