### PR TITLE
perf: add beta deployments (part 1: improvements)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -23,7 +23,7 @@
         "@keplr-wallet/stores": "^0.12.20",
         "@radix-ui/react-dialog": "^1.0.5",
         "@react-hook/resize-observer": "^1.2.6",
-        "@tanstack/react-query": "^5.0.0-alpha.35",
+        "@tanstack/react-query": "^5.18.1",
         "@visx/event": "^3.0.1",
         "@visx/group": "^3.0.0",
         "@visx/scale": "^3.0.0",
@@ -3527,37 +3527,27 @@
       "dev": true
     },
     "node_modules/@tanstack/query-core": {
-      "version": "5.0.0-alpha.34",
-      "resolved": "https://registry.npmjs.org/@tanstack/query-core/-/query-core-5.0.0-alpha.34.tgz",
-      "integrity": "sha512-/59XnJ7LDbEeliPx1xKvwjBNN3tpRUJxbaCn89qr11tjhNq5hRLQ301aQSxSdjvbFCHb8iOsGHzSb/e4m+3LXQ==",
+      "version": "5.18.1",
+      "resolved": "https://registry.npmjs.org/@tanstack/query-core/-/query-core-5.18.1.tgz",
+      "integrity": "sha512-fYhrG7bHgSNbnkIJF2R4VUXb4lF7EBiQjKkDc5wOlB7usdQOIN4LxxHpDxyE3qjqIst1WBGvDtL48T0sHJGKCw==",
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/tannerlinsley"
       }
     },
     "node_modules/@tanstack/react-query": {
-      "version": "5.0.0-alpha.35",
-      "resolved": "https://registry.npmjs.org/@tanstack/react-query/-/react-query-5.0.0-alpha.35.tgz",
-      "integrity": "sha512-a8Z9LhpTRKxDg3RJCV4Ri6a+0Vi2TwEQGqQpDT8pPklu/Iv0j00eMmyI5dUJAQk/xFRtZqDplm7MV4A0WvDwbw==",
+      "version": "5.18.1",
+      "resolved": "https://registry.npmjs.org/@tanstack/react-query/-/react-query-5.18.1.tgz",
+      "integrity": "sha512-PdI07BbsahZ+04PxSuDQsQvBWe008eWFk/YYWzt8fvzt2sALUM0TpAJa/DFpqa7+SSo7j1EQR6Jx6znXNHyaXw==",
       "dependencies": {
-        "@tanstack/query-core": "5.0.0-alpha.34"
+        "@tanstack/query-core": "5.18.1"
       },
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/tannerlinsley"
       },
       "peerDependencies": {
-        "react": "^18.0.0",
-        "react-dom": "^18.0.0",
-        "react-native": "*"
-      },
-      "peerDependenciesMeta": {
-        "react-dom": {
-          "optional": true
-        },
-        "react-native": {
-          "optional": true
-        }
+        "react": "^18.0.0"
       }
     },
     "node_modules/@testing-library/dom": {

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "@keplr-wallet/stores": "^0.12.20",
     "@radix-ui/react-dialog": "^1.0.5",
     "@react-hook/resize-observer": "^1.2.6",
-    "@tanstack/react-query": "^5.0.0-alpha.35",
+    "@tanstack/react-query": "^5.18.1",
     "@visx/event": "^3.0.1",
     "@visx/group": "^3.0.0",
     "@visx/scale": "^3.0.0",

--- a/src/components/cards/LimitOrderCard.tsx
+++ b/src/components/cards/LimitOrderCard.tsx
@@ -160,11 +160,11 @@ function LimitOrder({
   const tokenOut = buyMode ? tokenA : tokenB;
   const {
     data: userTokenInDisplayAmount,
-    isFetching: isLoadingUserTokenInDisplayAmount,
+    isValidating: isLoadingUserTokenInDisplayAmount,
   } = useBankBalanceDisplayAmount(tokenIn?.base);
   const {
     data: userTokenOutDisplayAmount,
-    isFetching: isLoadingUserTokenOutDisplayAmount,
+    isValidating: isLoadingUserTokenOutDisplayAmount,
   } = useBankBalanceDisplayAmount(tokenOut?.base);
 
   const [{ isValidating: isValidatingSwap, error }, swapRequest] = useSwap(

--- a/src/lib/web3/hooks/useDenomClients.ts
+++ b/src/lib/web3/hooks/useDenomClients.ts
@@ -13,6 +13,7 @@ import { DenomTrace } from '@duality-labs/neutronjs/types/codegen/ibc/applicatio
 import { useDenomTrace, useDenomTraceByDenom } from './useDenomsFromChain';
 import { Token } from '../utils/tokens';
 import { getAssetClient } from './useDenomsFromRegistry';
+import { SWRCommon, useSwrResponse } from './useSWR';
 
 const { REACT_APP__CHAIN_NAME = '' } = import.meta.env;
 
@@ -29,13 +30,6 @@ export function useAssetClient(denom: string | undefined) {
     }
   );
 }
-
-export type SWRCommon<Data = unknown, Error = unknown> = {
-  isValidating: boolean;
-  isLoading: boolean;
-  error: Error;
-  data: Data | undefined;
-};
 
 type AssetByDenom = Map<string, Asset>;
 type AssetClientByDenom = Map<string, ChainRegistryClient | null | undefined>;
@@ -97,12 +91,7 @@ function useAssetClientByDenom(
     },
   });
 
-  return {
-    isValidating: swr1.isValidating || swr2.isValidating,
-    isLoading: swr1.isLoading || swr2.isLoading,
-    error: swr1.error || swr2.error,
-    data: clientByDenom,
-  };
+  return useSwrResponse(clientByDenom, swr1, swr2);
 }
 
 export function useAssetChainUtilByDenom(
@@ -123,7 +112,7 @@ export function useAssetChainUtilByDenom(
     }, new Map());
   }, [uniqueDenoms, clientByDenom]);
 
-  return { ...swr, data };
+  return useSwrResponse(data, swr);
 }
 
 // export convenience hook for getting just Assets for each denom
@@ -146,7 +135,7 @@ export function useAssetByDenom(
     }, new Map());
   }, [uniqueDenoms, chainUtilByDenom]);
 
-  return { ...swr, data };
+  return useSwrResponse(data, swr);
 }
 
 // for possible types of assets in base denom
@@ -275,12 +264,7 @@ export function useTokenByDenom(
     }, new Map());
   }, [uniqueDenoms, clientByDenom, traceByDenom]);
 
-  return {
-    isValidating: swr1.isValidating || swr2.isValidating,
-    isLoading: swr1.isLoading || swr2.isLoading,
-    error: swr1.error || swr2.error,
-    data,
-  };
+  return useSwrResponse(data, swr1, swr2);
 }
 
 // export convenience hook for getting just one Token for one denom
@@ -292,7 +276,7 @@ export function useToken(denom: string | undefined): SWRCommon<Token> {
     return denom ? tokenByDenom?.get(denom) : undefined;
   }, [tokenByDenom, denom]);
 
-  return { ...swr, data };
+  return useSwrResponse(data, swr);
 }
 
 // export convenience hook for getting list of multiple Tokens
@@ -305,5 +289,5 @@ export function useTokens(denoms: string[] | undefined): SWRCommon<Token[]> {
     [tokenByDenom]
   );
 
-  return { ...swr, data };
+  return useSwrResponse(data, swr);
 }

--- a/src/lib/web3/hooks/useDenomClients.ts
+++ b/src/lib/web3/hooks/useDenomClients.ts
@@ -1,6 +1,6 @@
 import useSWRImmutable from 'swr/immutable';
 import { useQueries } from '@tanstack/react-query';
-import { useMemo } from 'react';
+import { useMemo, useRef } from 'react';
 import { useDeepCompareMemoize } from 'use-deep-compare-effect';
 import {
   ChainRegistryClient,
@@ -13,7 +13,7 @@ import { DenomTrace } from '@duality-labs/neutronjs/types/codegen/ibc/applicatio
 import { useDenomTrace, useDenomTraceByDenom } from './useDenomsFromChain';
 import { Token } from '../utils/tokens';
 import { getAssetClient } from './useDenomsFromRegistry';
-import { SWRCommon, useSwrResponse } from './useSWR';
+import { SWRCommon, isEqualMap, useSwrResponse } from './useSWR';
 
 const { REACT_APP__CHAIN_NAME = '' } = import.meta.env;
 
@@ -47,6 +47,7 @@ function useAssetClientByDenom(
   const swr1 = useDenomTraceByDenom(uniqueDenoms);
   const { data: denomTraceByDenom } = swr1;
 
+  const memoizedData = useRef<AssetClientByDenom>();
   const { data: clientByDenom, ...swr2 } = useQueries({
     queries: uniqueDenoms.flatMap((denom) => {
       const trace = denomTraceByDenom?.get(denom);
@@ -64,28 +65,37 @@ function useAssetClientByDenom(
       };
     }),
     combine: (results) => {
+      // compute data
+      const data = results.reduce<AssetClientByDenom>(
+        (map, { isPending, data: [denom, client] = [] }) => {
+          // if resolved then add data
+          if (!isPending && denom) {
+            const chainUtil = client?.getChainUtil(REACT_APP__CHAIN_NAME);
+            const asset = chainUtil?.getAssetByDenom(denom);
+            // if the client if found, return that
+            if (client && asset) {
+              return map.set(denom, client);
+            }
+            // if the client is undefined (pending) or null (not found/correct)
+            else {
+              return map.set(denom, client ? null : client);
+            }
+          }
+          return map;
+        },
+        new Map()
+      );
+
+      // update the memoized reference if the new data is different
+      if (!isEqualMap(data, memoizedData.current)) {
+        memoizedData.current = data;
+      }
+
+      // return memoized data and combined result state
       return {
+        data: memoizedData.current,
         isLoading: results.every((result) => result.isPending),
         isValidating: results.some((result) => result.isFetching),
-        data: results.reduce<AssetClientByDenom>(
-          (map, { isPending, data: [denom, client] = [] }) => {
-            // if resolved then add data
-            if (!isPending && denom) {
-              const chainUtil = client?.getChainUtil(REACT_APP__CHAIN_NAME);
-              const asset = chainUtil?.getAssetByDenom(denom);
-              // if the client if found, return that
-              if (client && asset) {
-                return map.set(denom, client);
-              }
-              // if the client is undefined (pending) or null (not found/correct)
-              else {
-                return map.set(denom, client ? null : client);
-              }
-            }
-            return map;
-          },
-          new Map()
-        ),
         error: results.find((result) => result.error)?.error,
       };
     },

--- a/src/lib/web3/hooks/useDenomClients.ts
+++ b/src/lib/web3/hooks/useDenomClients.ts
@@ -72,16 +72,7 @@ function useAssetClientByDenom(
     return results.reduce<AssetClientByDenom>((map, [denom, client]) => {
       // if resolved then add data
       if (denom) {
-        const chainUtil = client?.getChainUtil(REACT_APP__CHAIN_NAME);
-        const asset = chainUtil?.getAssetByDenom(denom);
-        // if the client if found, return that
-        if (client && asset) {
-          return map.set(denom, client);
-        }
-        // if the client is undefined (pending) or null (not found/correct)
-        else {
-          return map.set(denom, client ? null : client);
-        }
+        return map.set(denom, client);
       }
       return map;
     }, new Map());

--- a/src/lib/web3/hooks/useDenomClients.ts
+++ b/src/lib/web3/hooks/useDenomClients.ts
@@ -1,6 +1,6 @@
 import useSWRImmutable from 'swr/immutable';
 import { useQueries } from '@tanstack/react-query';
-import { useMemo, useRef } from 'react';
+import { useMemo } from 'react';
 import { useDeepCompareMemoize } from 'use-deep-compare-effect';
 import {
   ChainRegistryClient,
@@ -13,7 +13,7 @@ import { DenomTrace } from '@duality-labs/neutronjs/types/codegen/ibc/applicatio
 import { useDenomTrace, useDenomTraceByDenom } from './useDenomsFromChain';
 import { Token } from '../utils/tokens';
 import { getAssetClient } from './useDenomsFromRegistry';
-import { SWRCommon, isEqualMap, useSwrResponse } from './useSWR';
+import { SWRCommon, useCombineResults, useSwrResponse } from './useSWR';
 
 const { REACT_APP__CHAIN_NAME = '' } = import.meta.env;
 
@@ -47,8 +47,7 @@ function useAssetClientByDenom(
   const swr1 = useDenomTraceByDenom(uniqueDenoms);
   const { data: denomTraceByDenom } = swr1;
 
-  const memoizedData = useRef<AssetClientByDenom>();
-  const { data: clientByDenom, ...swr2 } = useQueries({
+  const { data: results, ...swr2 } = useQueries({
     queries: uniqueDenoms.flatMap((denom) => {
       const trace = denomTraceByDenom?.get(denom);
       return {
@@ -64,42 +63,29 @@ function useAssetClientByDenom(
         refetchOnWindowFocus: false,
       };
     }),
-    combine: (results) => {
-      // compute data
-      const data = results.reduce<AssetClientByDenom>(
-        (map, { isPending, data: [denom, client] = [] }) => {
-          // if resolved then add data
-          if (!isPending && denom) {
-            const chainUtil = client?.getChainUtil(REACT_APP__CHAIN_NAME);
-            const asset = chainUtil?.getAssetByDenom(denom);
-            // if the client if found, return that
-            if (client && asset) {
-              return map.set(denom, client);
-            }
-            // if the client is undefined (pending) or null (not found/correct)
-            else {
-              return map.set(denom, client ? null : client);
-            }
-          }
-          return map;
-        },
-        new Map()
-      );
-
-      // update the memoized reference if the new data is different
-      if (!isEqualMap(data, memoizedData.current)) {
-        memoizedData.current = data;
-      }
-
-      // return memoized data and combined result state
-      return {
-        data: memoizedData.current,
-        isLoading: results.every((result) => result.isPending),
-        isValidating: results.some((result) => result.isFetching),
-        error: results.find((result) => result.error)?.error,
-      };
-    },
+    // use generic simple as possible combination
+    combine: useCombineResults(),
   });
+
+  const clientByDenom = useMemo(() => {
+    // compute map
+    return results.reduce<AssetClientByDenom>((map, [denom, client]) => {
+      // if resolved then add data
+      if (denom) {
+        const chainUtil = client?.getChainUtil(REACT_APP__CHAIN_NAME);
+        const asset = chainUtil?.getAssetByDenom(denom);
+        // if the client if found, return that
+        if (client && asset) {
+          return map.set(denom, client);
+        }
+        // if the client is undefined (pending) or null (not found/correct)
+        else {
+          return map.set(denom, client ? null : client);
+        }
+      }
+      return map;
+    }, new Map());
+  }, [results]);
 
   return useSwrResponse(clientByDenom, swr1, swr2);
 }

--- a/src/lib/web3/hooks/useDenomsFromChain.ts
+++ b/src/lib/web3/hooks/useDenomsFromChain.ts
@@ -47,6 +47,7 @@ export function useDenomTraceByDenom(
                 ? await restClient.applications.transfer.v1
                     .denomTrace({ hash })
                     .then((response) => response.denom_trace)
+                    .catch(() => undefined)
                 : undefined,
             ];
           },

--- a/src/lib/web3/hooks/useDenomsFromChain.ts
+++ b/src/lib/web3/hooks/useDenomsFromChain.ts
@@ -1,10 +1,11 @@
 import { useQueries } from '@tanstack/react-query';
 import { useDeepCompareMemoize } from 'use-deep-compare-effect';
+import { useRef } from 'react';
 import { DenomTrace } from '@duality-labs/neutronjs/types/codegen/ibc/applications/transfer/v1/transfer';
 
 import { useIbcRestClient } from '../clients/restClients';
 import { useDefaultDenomTraceByDenom } from './useDenomsFromRegistry';
-import { SWRCommon, useSwrResponse } from './useSWR';
+import { SWRCommon, isEqualMap, useSwrResponse } from './useSWR';
 
 type DenomTraceByDenom = Map<string, DenomTrace>;
 
@@ -28,6 +29,7 @@ export function useDenomTraceByDenom(
 
   const restClient = useIbcRestClient();
 
+  const memoizedData = useRef<DenomTraceByDenom>();
   const { data: denomTraceByDenom, ...swr } = useQueries({
     queries: ibcDenoms.flatMap((denom) => {
       const hash = denom.split('ibc/').at(1);
@@ -62,19 +64,28 @@ export function useDenomTraceByDenom(
       return [];
     }),
     combine: (results) => {
+      // compute data
+      const data = results.reduce<DenomTraceByDenom>(
+        (map, { data: [denom, trace] = [] }) => {
+          // if resolved then add data
+          if (denom && trace) {
+            return map.set(denom, trace);
+          }
+          return map;
+        },
+        new Map()
+      );
+
+      // update the memoized reference if the new data is different
+      if (!isEqualMap(data, memoizedData.current)) {
+        memoizedData.current = data;
+      }
+
+      // return memoized data and combined result state
       return {
+        data: memoizedData.current,
         isLoading: results.every((result) => result.isPending),
         isValidating: results.some((result) => result.isFetching),
-        data: results.reduce<DenomTraceByDenom>(
-          (map, { data: [denom, trace] = [] }) => {
-            // if resolved then add data
-            if (denom && trace) {
-              return map.set(denom, trace);
-            }
-            return map;
-          },
-          new Map()
-        ),
         error: results.find((result) => result.error)?.error,
       };
     },

--- a/src/lib/web3/hooks/useDenomsFromChain.ts
+++ b/src/lib/web3/hooks/useDenomsFromChain.ts
@@ -39,16 +39,22 @@ export function useDenomTraceByDenom(
       const hash = denom.split('ibc/').at(1);
       if (restClient && hash) {
         return {
-          queryKey: ['useDenomTraceByDenom', denom, hash],
+          queryKey: [
+            'useDenomTraceByDenom',
+            denom,
+            hash,
+            defaultDenomTraceByDenom?.size,
+          ],
           queryFn: async (): Promise<[string, DenomTrace?]> => {
+            const foundDefaultTrace = defaultDenomTraceByDenom?.get(denom);
             return [
               denom,
-              hash
-                ? await restClient.applications.transfer.v1
-                    .denomTrace({ hash })
-                    .then((response) => response.denom_trace)
-                    .catch(() => undefined)
-                : undefined,
+              foundDefaultTrace ||
+                (hash
+                  ? await restClient.applications.transfer.v1
+                      .denomTrace({ hash })
+                      .then((response) => response.denom_trace)
+                  : undefined),
             ];
           },
           // never refetch these values, they will never change

--- a/src/lib/web3/hooks/useDenomsFromChain.ts
+++ b/src/lib/web3/hooks/useDenomsFromChain.ts
@@ -4,15 +4,9 @@ import { DenomTrace } from '@duality-labs/neutronjs/types/codegen/ibc/applicatio
 
 import { useIbcRestClient } from '../clients/restClients';
 import { useDefaultDenomTraceByDenom } from './useDenomsFromRegistry';
+import { SWRCommon, useSwrResponse } from './useSWR';
 
 type DenomTraceByDenom = Map<string, DenomTrace>;
-
-type SWRCommon<Data = unknown, Error = unknown> = {
-  isValidating: boolean;
-  isLoading: boolean;
-  error: Error;
-  data: Data | undefined;
-};
 
 export function useDenomTraceByDenom(
   denoms: string[]
@@ -86,11 +80,10 @@ export function useDenomTraceByDenom(
     },
   });
 
-  const { isValidating, isLoading, error } = swr;
-  return { isValidating, isLoading, error, data: denomTraceByDenom };
+  return useSwrResponse(denomTraceByDenom, swr);
 }
 
 export function useDenomTrace(denom = ''): SWRCommon<DenomTrace> {
   const { data: denomTraceByDenom, ...swr } = useDenomTraceByDenom([denom]);
-  return { ...swr, data: denomTraceByDenom?.get(denom) };
+  return useSwrResponse<DenomTrace>(denomTraceByDenom?.get(denom), swr);
 }

--- a/src/lib/web3/hooks/useDenomsFromChain.ts
+++ b/src/lib/web3/hooks/useDenomsFromChain.ts
@@ -1,6 +1,4 @@
-import useSWRInfinite, { SWRInfiniteKeyLoader } from 'swr/infinite';
-import { immutable } from 'swr/immutable';
-import { useEffect, useMemo } from 'react';
+import { useQueries } from '@tanstack/react-query';
 import { useDeepCompareMemoize } from 'use-deep-compare-effect';
 import { DenomTrace } from '@duality-labs/neutronjs/types/codegen/ibc/applications/transfer/v1/transfer';
 
@@ -35,64 +33,54 @@ export function useDenomTraceByDenom(
   );
 
   const restClient = useIbcRestClient();
-  const swr = useSWRInfinite<
-    [string, DenomTrace?],
-    Error,
-    SWRInfiniteKeyLoader<DenomTrace, [denom: string, namespace: string]>
-  >(
-    // allow hash to be an empty string
-    (index: number) => [ibcDenoms.at(index) || '', 'denom-trace'],
-    // handle cases of undefined client and empty hash string
-    restClient
-      ? async ([denom]) => {
-          const hash = denom.split('ibc/').at(1);
-          return [
-            denom,
-            // fetch denom trace only if the denom has an IBC hash
-            hash
-              ? await restClient.applications.transfer.v1
-                  .denomTrace({ hash })
-                  .then((response) => response.denom_trace)
-              : undefined,
-          ];
-        }
-      : null,
-    // these endpoint responses never change
-    {
-      parallel: true,
-      initialSize: 1,
-      use: [immutable],
-      revalidateFirstPage: false,
-      revalidateAll: false,
-      errorRetryCount: 3,
-    }
-  );
 
-  // get all pages, resolving one key at a time
-  const { size, setSize } = swr;
-  useEffect(() => {
-    if (size < ibcDenoms.length) {
-      setSize((size) => Math.min(ibcDenoms.length, size + 1));
-    }
-  }, [size, setSize, ibcDenoms]);
-
-  // combine pages into one
-  const { data: pages } = swr;
-  const data = useMemo<DenomTraceByDenom | undefined>(() => {
-    return pages?.reduce<DenomTraceByDenom>(
-      (map, [denom, denomTrace] = ['']) => {
-        if (denom && denomTrace) {
-          return map.set(denom, denomTrace);
-        }
-        return map;
-      },
-      // create m denom map from base denom map created from chain-registry data
-      new Map(defaultDenomTraceByDenom)
-    );
-  }, [defaultDenomTraceByDenom, pages]);
+  const { data: denomTraceByDenom, ...swr } = useQueries({
+    queries: ibcDenoms.flatMap((denom) => {
+      const hash = denom.split('ibc/').at(1);
+      if (restClient && hash) {
+        return {
+          queryKey: ['useDenomTraceByDenom', denom, hash],
+          queryFn: async (): Promise<[string, DenomTrace?]> => {
+            return [
+              denom,
+              hash
+                ? await restClient.applications.transfer.v1
+                    .denomTrace({ hash })
+                    .then((response) => response.denom_trace)
+                : undefined,
+            ];
+          },
+          // never refetch these values, they will never change
+          staleTime: Infinity,
+          refetchInterval: Infinity,
+          refetchOnMount: false,
+          refetchOnReconnect: false,
+          refetchOnWindowFocus: false,
+        };
+      }
+      return [];
+    }),
+    combine: (results) => {
+      return {
+        isLoading: results.every((result) => result.isPending),
+        isValidating: results.some((result) => result.isFetching),
+        data: results.reduce<DenomTraceByDenom>(
+          (map, { data: [denom, trace] = [] }) => {
+            // if resolved then add data
+            if (denom && trace) {
+              return map.set(denom, trace);
+            }
+            return map;
+          },
+          new Map()
+        ),
+        error: results.find((result) => result.error)?.error,
+      };
+    },
+  });
 
   const { isValidating, isLoading, error } = swr;
-  return { isValidating, isLoading, error, data };
+  return { isValidating, isLoading, error, data: denomTraceByDenom };
 }
 
 export function useDenomTrace(denom = ''): SWRCommon<DenomTrace> {

--- a/src/lib/web3/hooks/useDenomsFromRegistry.ts
+++ b/src/lib/web3/hooks/useDenomsFromRegistry.ts
@@ -1,5 +1,4 @@
 import useSWRImmutable from 'swr/immutable';
-import { SWRResponse } from 'swr';
 import { useMemo } from 'react';
 import {
   ChainRegistryClient,
@@ -9,6 +8,7 @@ import {
 import { ibcDenom, getIbcAssetPath } from '@chain-registry/utils';
 import { Asset, AssetList, Chain, IBCInfo } from '@chain-registry/types';
 import { DenomTrace } from '@duality-labs/neutronjs/types/codegen/ibc/applications/transfer/v1/transfer';
+import { SWRCommon, useSwrResponse } from './useSWR';
 
 const {
   REACT_APP__CHAIN_NAME = '',
@@ -343,14 +343,12 @@ function useDefaultAssetsClient() {
   );
 }
 
-export function useChainUtil(): SWRResponse<ChainRegistryChainUtil> {
+export function useChainUtil(): SWRCommon<ChainRegistryChainUtil> {
   const { data, ...swr } = useDefaultAssetsClient();
   // return just the chain utility instance
   // it is possible to get the original fetcher at chainUtil.chainInfo.fetcher
-  return {
-    ...swr,
-    data: useMemo(() => data?.getChainUtil(REACT_APP__CHAIN_NAME), [data]),
-  } as SWRResponse;
+  const util = useMemo(() => data?.getChainUtil(REACT_APP__CHAIN_NAME), [data]);
+  return useSwrResponse(util, swr);
 }
 
 export function useChainNativeAssetList(): AssetList | undefined {
@@ -431,7 +429,7 @@ function getDenomTraceFromAsset(
     : undefined;
 }
 // get denom traces from default IBC network (one-hop)
-export function useDefaultDenomTraceByDenom(): SWRResponse<DenomTraceByDenom> {
+export function useDefaultDenomTraceByDenom(): SWRCommon<DenomTraceByDenom> {
   const { data: client, ...swr } = useDefaultAssetsClient();
 
   // find the IBC trace information of each known IBC asset
@@ -457,5 +455,5 @@ export function useDefaultDenomTraceByDenom(): SWRResponse<DenomTraceByDenom> {
       : map;
   }, [client]);
 
-  return { ...swr, data: defaultDenomTraceByDenom } as SWRResponse;
+  return useSwrResponse<DenomTraceByDenom>(defaultDenomTraceByDenom, swr);
 }

--- a/src/lib/web3/hooks/useSWR.ts
+++ b/src/lib/web3/hooks/useSWR.ts
@@ -1,0 +1,55 @@
+import { UseQueryResult } from '@tanstack/react-query';
+import { useMemo } from 'react';
+import { SWRResponse } from 'swr';
+
+export type SWRCommon<Data = unknown, Error = unknown> = Omit<
+  SWRResponse<Data, Error>,
+  'mutate'
+>;
+
+export function useSwrResponse<T>(
+  data: T | undefined,
+  swr1: Omit<SWRCommon, 'data'>,
+  swr2?: Omit<SWRCommon, 'data'>
+): SWRCommon<T> {
+  return useMemo(() => {
+    return {
+      isLoading: !!(swr1.isLoading || swr2?.isLoading),
+      isValidating: !!(swr1.isValidating || swr2?.isValidating),
+      error: swr1.error || swr2?.error,
+      data,
+    };
+  }, [
+    data,
+    swr1.isLoading,
+    swr1.isValidating,
+    swr1.error,
+    swr2?.isLoading,
+    swr2?.isValidating,
+    swr2?.error,
+  ]);
+}
+
+export function useSwrResponseFromReactQuery<T>(
+  data: T | undefined,
+  queryResult1: Omit<UseQueryResult, 'data'>,
+  queryResult2?: Omit<UseQueryResult, 'data'>
+): SWRCommon<T> {
+  const swr1 = useMemo(
+    () => ({
+      isLoading: queryResult1.isPending,
+      isValidating: queryResult1.isFetching,
+      error: queryResult1.error || undefined,
+    }),
+    [queryResult1]
+  );
+  const swr2 = useMemo(
+    () => ({
+      isLoading: !!queryResult2?.isPending,
+      isValidating: !!queryResult2?.isFetching,
+      error: queryResult2?.error || undefined,
+    }),
+    [queryResult2]
+  );
+  return useSwrResponse(data, swr1, swr2);
+}

--- a/src/lib/web3/hooks/useSWR.ts
+++ b/src/lib/web3/hooks/useSWR.ts
@@ -53,3 +53,28 @@ export function useSwrResponseFromReactQuery<T>(
   );
   return useSwrResponse(data, swr1, swr2);
 }
+
+export function isEqualMap<K, V>(
+  map1: Map<K, V>,
+  map2: Map<K, V> = new Map<K, V>()
+): boolean {
+  // compare map keys and values if they are the same size
+  if (map1.size === map2.size) {
+    const entries1 = map1.entries();
+    const entries2 = map2.entries();
+    for (let i = 0; i < map1.size; i++) {
+      const [key1, value1] = entries1.next().value;
+      const [key2, value2] = entries2.next().value;
+      if (key1 !== key2 || value1 !== value2) {
+        // an item is different
+        return false;
+      }
+    }
+    // no changes found
+    return true;
+  }
+  // the map size is different
+  else {
+    return false;
+  }
+}

--- a/src/lib/web3/hooks/useTokens.ts
+++ b/src/lib/web3/hooks/useTokens.ts
@@ -11,13 +11,9 @@ import {
 import { useSimplePrice } from '../../tokenPrices';
 import { useNativeChain } from './useChains';
 import { useOneHopDenoms } from './useDenomsFromRegistry';
-import {
-  SWRCommon,
-  TokenByDenom,
-  useToken,
-  useTokenByDenom,
-} from './useDenomClients';
+import { TokenByDenom, useToken, useTokenByDenom } from './useDenomClients';
 import { useUserBankValues } from './useUserBankValues';
+import { SWRCommon, useSwrResponse } from './useSWR';
 
 const { REACT_APP__CHAIN_ID = '' } = import.meta.env;
 
@@ -81,7 +77,7 @@ export function useDenomFromPathParam(
     // return denom of resolved token, or the passed param which may be a denom
     return tokens.find(matchTokenBySymbol(pathParam))?.base ?? pathParam;
   }, [tokenByDenom, pathParam]);
-  return { ...swr, data: denom };
+  return useSwrResponse(denom, swr);
 }
 
 // return token identifier that can be used as a part of a URL

--- a/src/lib/web3/hooks/useUserBankBalances.ts
+++ b/src/lib/web3/hooks/useUserBankBalances.ts
@@ -43,7 +43,7 @@ function useAllUserBankBalances(): SWRCommon<Coin[]> {
         } as PageRequest,
       });
     },
-    defaultPageParam: undefined as Uint8Array | undefined,
+    initialPageParam: undefined as Uint8Array | undefined,
     getNextPageParam: (lastPage): Uint8Array | undefined => {
       // don't pass an empty array as that will trigger another page to download
       return lastPage?.pagination?.next_key?.length

--- a/src/lib/web3/hooks/useUserDeposits.ts
+++ b/src/lib/web3/hooks/useUserDeposits.ts
@@ -37,7 +37,7 @@ function useAllUserDeposits(): UseQueryResult<DepositRecord[]> {
         return response;
       }
     },
-    defaultPageParam: undefined as Uint8Array | undefined,
+    initialPageParam: undefined as Uint8Array | undefined,
     getNextPageParam: (lastPage): Uint8Array | undefined => {
       // don't pass an empty array as that will trigger another page to download
       return lastPage?.pagination?.next_key?.length

--- a/src/pages/Pool/PoolChart.tsx
+++ b/src/pages/Pool/PoolChart.tsx
@@ -148,7 +148,7 @@ function useTimeSeriesData(
       const response = await fetch(`${REACT_APP__INDEXER_API}/${path}${query}`);
       return await response.json();
     },
-    defaultPageParam: '',
+    initialPageParam: '',
     getNextPageParam: (lastPage: TimeSeriesPage) => {
       // don't pass an empty array as that will trigger another page to download
       return lastPage?.pagination?.next_key?.length


### PR DESCRIPTION
This PR improves general performance of fetching and token utility computation which caused great losses of frame rate when attempting to run the app on mainnet data in the upcoming beta deployment:

- doesn't attempt to look up every denom from the chain
  - if the data was already found on chain-registry then trust that data
- makes usage of hooks with react-query and useSWR libraries to be more consistent with a new combined return Type
- reduces re-computation of many compute intensive chain-registry util class instances by caching these with useSWR
  - this is very noticeable with mainnet data where several hundred token utility classes can be recomputed often.
- updates react-query to a non-alpha version
