### PR TITLE
fix: allow local development setup with Neutron CosmoPark

### DIFF
--- a/src/lib/tokenPrices.ts
+++ b/src/lib/tokenPrices.ts
@@ -4,7 +4,7 @@ import { useEffect, useMemo } from 'react';
 import { ObservableList, useObservableList } from './utils/observableList';
 import { Token } from './web3/utils/tokens';
 
-const { REACT_APP__DEV_ASSET_PRICE_MAP } = import.meta.env;
+const { DEV, REACT_APP__DEV_ASSET_PRICE_MAP } = import.meta.env;
 
 const baseAPI = 'https://api.coingecko.com/api/v3';
 
@@ -183,7 +183,9 @@ export function useSimplePrice(
     return tokens.map((token) =>
       token?.coingecko_id
         ? // if the information is fetchable, return fetched (number) or not yet fetched (undefined)
-          (data?.[token.coingecko_id]?.[currencyID] as number | undefined)
+          (data?.[token.coingecko_id]?.[currencyID] as number | undefined) ??
+          // in dev, if is stablecoin query (USDC/USD or USDT/USD) default to 1
+          (DEV && token.coingecko_id.startsWith(currencyID) ? 1 : undefined)
         : // if the information is not fetchable, return a dev token price or 0 (unpriced)
           getDevTokenPrice(token) || 0
     );

--- a/src/lib/web3/hooks/useTokens.ts
+++ b/src/lib/web3/hooks/useTokens.ts
@@ -15,7 +15,7 @@ import { TokenByDenom, useToken, useTokenByDenom } from './useDenomClients';
 import { useUserBankValues } from './useUserBankValues';
 import { SWRCommon, useSwrResponse } from './useSWR';
 
-const { REACT_APP__CHAIN_ID = '' } = import.meta.env;
+const { REACT_APP__CHAIN_NAME = '' } = import.meta.env;
 
 export function useChainFeeToken(): [
   Token | undefined,
@@ -142,9 +142,9 @@ export function matchTokenByDenom(denom: string) {
       return matchTokenBySymbol(denom);
     }
     // match native chain token denoms only
-    else if (REACT_APP__CHAIN_ID) {
+    else if (REACT_APP__CHAIN_NAME) {
       return (token: Token) =>
-        token.chain.chain_id === REACT_APP__CHAIN_ID &&
+        token.chain.chain_name === REACT_APP__CHAIN_NAME &&
         !!token.denom_units.find((unit) => unit.denom === denom);
     }
   }

--- a/src/lib/web3/wallets/keplr.ts
+++ b/src/lib/web3/wallets/keplr.ts
@@ -48,14 +48,14 @@ export async function getKeplrDualityWallet(
 ): Promise<KeplrWallet | undefined> {
   try {
     invariant(chain, 'Chain is not set');
+    const chainId = chain.chain_id;
+    invariant(chainId, `Invalid chain id: ${chainId}`);
     const chainName = chain.chain_name;
     invariant(chainName, `Invalid chain name: ${chainName}`);
     const keplr = await getKeplr();
     invariant(keplr, 'Keplr extension is not installed or enabled');
     const chainClient = await getChainClient(chainName);
     const chainAssetList = chainClient.getChainAssetList(chainName);
-    const chainId = chain.chain_id;
-    invariant(chainId, `Invalid chain id: ${chainId}`);
     const chainInfo = chainRegistryChainToKeplr(chain, [chainAssetList]);
     await keplr.experimentalSuggestChain(chainInfo);
     await keplr.enable(chainId);
@@ -112,7 +112,7 @@ export async function getChainInfo(chain: Chain) {
   invariant(chainId, `Invalid chain id: ${chainId}`);
   const keplr = await getKeplr();
   invariant(keplr, 'Keplr extension is not installed or enabled');
-  const chainName: string = chain.chain_name;
+  const chainName = chain.chain_name;
   invariant(chainName, `Invalid chain name: ${chainName}`);
   const chainClient = await getChainClient(chainName);
   const chainAssetList = chainClient.getChainAssetList(chainName);

--- a/src/lib/web3/wallets/keplr.ts
+++ b/src/lib/web3/wallets/keplr.ts
@@ -7,8 +7,6 @@ import { Chain } from '@chain-registry/types';
 import { chainRegistryChainToKeplr } from '@chain-registry/keplr';
 import { getChainClient } from '../hooks/useDenomsFromRegistry';
 
-const { REACT_APP__CHAIN_NAME } = import.meta.env;
-
 declare global {
   interface Window extends KeplrWindow {
     keplr: Keplr;
@@ -45,16 +43,16 @@ async function getKeplr(): Promise<Keplr | undefined> {
 type KeplrWallet = OfflineSigner;
 type KeplrWalletAccount = AccountData;
 
-export async function getKeplrDualityWallet(): Promise<
-  KeplrWallet | undefined
-> {
+export async function getKeplrDualityWallet(
+  chain: Chain
+): Promise<KeplrWallet | undefined> {
   try {
+    invariant(chain, 'Chain is not set');
+    const chainName = chain.chain_name;
+    invariant(chainName, `Invalid chain name: ${chainName}`);
     const keplr = await getKeplr();
     invariant(keplr, 'Keplr extension is not installed or enabled');
-    const chainName: string = REACT_APP__CHAIN_NAME;
-    invariant(chainName, `Invalid chain name: ${chainName}`);
     const chainClient = await getChainClient(chainName);
-    const chain = chainClient.getChain(chainName);
     const chainAssetList = chainClient.getChainAssetList(chainName);
     const chainId = chain.chain_id;
     invariant(chainId, `Invalid chain id: ${chainId}`);


### PR DESCRIPTION
Neutron Cosmopark setup: https://docs.neutron.org/neutron/build-and-run/cosmopark/

As a developer, I'd like to be able to develop the web app using a local chain and indexer as a source of data:
- local chain: https://github.com/neutron-org/neutron-integration-tests
    - OR local chain with trading bot simulation: [https://github.com/neutron-org/dex-trading-bot](https://github.com/neutron-org/dex-trading-bot/tree/improve-multiple-bot-usage)
- indexer: https://github.com/duality-labs/hapi-indexer

Some fixes with the chain properties and how they are passed to Keplr are needed
- remove chain ID matching and replaces with the more expected chain name matching
- Also resolves `USDC` token prices locally.